### PR TITLE
Sql endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7.5
 
 # Ensure that the python output is sent straight to terminal
 ENV PYTHONUNBUFFERED=1

--- a/cdb_rest/queries.py
+++ b/cdb_rest/queries.py
@@ -1,0 +1,32 @@
+get_payload_iovs = '''
+WITH major_max_table AS(
+    SELECT m.payload_list_id, m.payload_url, m.major_iov, m.minor_iov, t.major_max--, l.name
+    FROM (
+        SELECT payload_list_id, MAX(major_iov) AS major_max
+        FROM "PayloadIOV"
+        WHERE ((major_iov < %(my_major_iov)s) OR (major_iov = %(my_major_iov)s AND minor_iov <= %(my_minor_iov)s))
+        AND payload_list_id IN (
+            SELECT id FROM "PayloadList"
+            WHERE global_tag_id = (
+                SELECT id FROM "GlobalTag"
+                WHERE name = %(my_gt)s
+            )
+        )
+    GROUP BY payload_list_id
+    ) t JOIN "PayloadIOV" m ON m.payload_list_id = t.payload_list_id AND t.major_max = m.major_iov
+),
+major_minor_max_table AS(
+    SELECT n.payload_list_id, n.payload_url, n.major_iov, n.minor_iov
+    FROM (
+        SELECT payload_list_id, MAX(minor_iov) AS minor_max
+        FROM major_max_table
+        GROUP BY payload_list_id
+    ) u JOIN major_max_table n ON n.payload_list_id = u.payload_list_id AND u.minor_max = n.minor_iov
+)
+SELECT y.name AS payload_type_name, x.payload_url, x.major_iov, x.minor_iov
+FROM
+  major_minor_max_table x
+  JOIN "PayloadList" z ON x.payload_list_id = z.id
+  JOIN "PayloadType" y ON z.payload_type_id = y.id
+;
+'''

--- a/cdb_rest/queries.py
+++ b/cdb_rest/queries.py
@@ -1,6 +1,6 @@
 get_payload_iovs = '''
 WITH major_max_table AS(
-    SELECT m.payload_list_id, m.payload_url, m.major_iov, m.minor_iov, t.major_max--, l.name
+    SELECT m.payload_list_id, m.payload_url, m.major_iov, m.minor_iov, t.major_max
     FROM (
         SELECT payload_list_id, MAX(major_iov) AS major_max
         FROM "PayloadIOV"

--- a/cdb_rest/urls.py
+++ b/cdb_rest/urls.py
@@ -2,7 +2,8 @@ from django.urls import path
 from cdb_rest.views import GlobalTagListCreationAPIView, GlobalTagDetailAPIView, GlobalTagStatusCreationAPIView
 from cdb_rest.views import GlobalTagsListAPIView, GlobalTagsPayloadListsListAPIView, GlobalTagByNameDetailAPIView
 from cdb_rest.views import PayloadListListCreationAPIView, PayloadTypeListCreationAPIView, PayloadIOVListCreationAPIView, PayloadListDetailAPIView
-from cdb_rest.views import PayloadIOVsListAPIView, PayloadIOVsList2APIView, PayloadIOVsListFastAPIView, PayloadIOVsListTestMaxAPIView,PayloadIOVsRangesListAPIView, PayloadListDetailAPIView, PayloadIOVDetailAPIView
+from cdb_rest.views import PayloadIOVsListAPIView, PayloadIOVsList2APIView, PayloadIOVsListFastAPIView, PayloadIOVsListTestMaxAPIView,\
+    PayloadIOVsSQLListAPIView, PayloadIOVsRangesListAPIView, PayloadListDetailAPIView, PayloadIOVDetailAPIView
 from cdb_rest.views import PayloadListAttachAPIView, GlobalTagChangeStatusAPIView, PayloadIOVAttachAPIView
 from cdb_rest.views import PayloadIOVBulkCreationAPIView
 from cdb_rest.views import GlobalTagDeleteAPIView
@@ -50,6 +51,7 @@ urlpatterns = [
     path('payloadiovsfast/', PayloadIOVsListFastAPIView.as_view(), name="payloadiovsfast"),
     path('payloadiovstest/', PayloadIOVsListTestMaxAPIView.as_view(), name="payloadiovstest"),
     path('payloadiovsrange/', PayloadIOVsRangesListAPIView.as_view(), name="payload_ranges_list"),
+    path('payloadiovssql/', PayloadIOVsSQLListAPIView.as_view(), name="payloadiovssql"),
 
     path('gt_change_status/<str:globalTagName>/<str:newStatus>', GlobalTagChangeStatusAPIView.as_view(), name="global_tag_change_status")
 

--- a/cdb_rest/views.py
+++ b/cdb_rest/views.py
@@ -11,7 +11,7 @@ from cdb_rest.authentication import CustomJWTAuthentication
 from django.shortcuts import get_object_or_404
 
 
-from django.db import transaction
+from django.db import transaction, connection
 
 from django.db.models import Prefetch
 from django.db.models import Q
@@ -26,6 +26,7 @@ from cdb_rest.serializers import PayloadListCreateSerializer, PayloadListReadSer
 from cdb_rest.serializers import PayloadIOVSerializer
 from cdb_rest.serializers import PayloadListSerializer, PayloadListReadShortSerializer
 #from cdb_rest.serializers import PayloadListIdSeqSerializer
+import cdb_rest.queries
 
 from cdb_rest.authentication import CustomJWTAuthentication
 
@@ -512,6 +513,19 @@ class PayloadIOVsListTestAPIView(ListAPIView):
         #print(plists)
         #serializer = PayloadIOVSerializer(payloads)
         return Response(json.dumps(ret))
+
+
+class PayloadIOVsSQLListAPIView(ListAPIView):
+
+    def list(self, request):
+        with connection.cursor() as cursor:
+            cursor.execute(cdb_rest.queries.get_payload_iovs,
+               {'my_major_iov': self.request.GET.get('majorIOV'),
+                'my_minor_iov': self.request.GET.get('minorIOV'),
+                'my_gt': self.request.GET.get('gtName')})
+            row = cursor.fetchall()
+        return Response(row)
+
 
 #Interface to take list of PayloadIOVs ranges groupped by PayloadLists for a given GT and IOVs
 class PayloadIOVsRangesListAPIView(ListAPIView):


### PR DESCRIPTION
Implemented a new endpoint to retrieve payload ions for a given global tag, major- and minor iov. It uses raw SQL query and is much faster than previously best method relying on the ORM.