### PR TITLE
Reduced size of docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,26 @@
-FROM python:3.9.16
-
+FROM python:3.9.16 AS builder
 # Ensure that the python output is sent straight to terminal
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONDONTWRITEBYTECODE=1
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
 WORKDIR /npdb
-COPY requirements.txt requirements.txt
-RUN pip install --upgrade pip
-RUN pip install -r requirements.txt
-COPY . /npdb
+COPY requirements.txt .
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+FROM python:3.9.16
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+
+COPY --from=builder /npdb /app
 
 ENTRYPOINT ["/bin/sh", "-c" , "python manage.py makemigrations cdb_rest && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]
 CMD ["/bin/bash"]


### PR DESCRIPTION
Using Multi-stage build, reduced Docker image size from 961MB → 905MB by removing unnecessary layers.

<img width="511" alt="Screenshot 2025-02-19 at 02 19 11" src="https://github.com/user-attachments/assets/5ff88329-5692-4bbb-b633-5893a1777fd8" />
