### PR TITLE
Fix comb_iov calculation in PayloadIOVAttachAPIView

### DIFF
--- a/cdb_rest/views.py
+++ b/cdb_rest/views.py
@@ -880,7 +880,7 @@ class PayloadIOVAttachAPIView(UpdateAPIView):
                     # piovs[0].update(major_iov=piov.major_iov_end, minor_iov=piov.minor_iov_end)
                     piovs[0].major_iov = piov.major_iov_end
                     piovs[0].minor_iov = piov.minor_iov_end
-                    piovs[0].comb_iov = Decimal(Decimal(piovs[0].major_iov) + Decimal(piovs[0].major_iov) / 10 ** 19)
+                    piovs[0].comb_iov = Decimal(Decimal(piovs[0].major_iov) + Decimal(piovs[0].minor_iov) / 10 ** 19)
                     piovs[0].save(update_fields=['major_iov', 'minor_iov', 'comb_iov'])
 
         piov.payload_list = p_list


### PR DESCRIPTION
## Summary

Fixes a copy-paste bug in `cdb_rest/views.py` line 883 where `major_iov` is used twice in the `comb_iov` formula instead of using `minor_iov` for the second term.

## The Bug

```python
# Line 883 (current — incorrect):
piovs[0].comb_iov = Decimal(Decimal(piovs[0].major_iov) + Decimal(piovs[0].major_iov) / 10 ** 19)
#                                                                       ^^^^^^^^^ should be minor_iov
```

## The Fix

```python
piovs[0].comb_iov = Decimal(Decimal(piovs[0].major_iov) + Decimal(piovs[0].minor_iov) / 10 ** 19)
```

## Evidence

The correct formula (`major_iov + minor_iov / 10^19`) is used in all other locations in the same file:

| Line | Second term | Correct? |
|------|------------|----------|
| 400 | `Decimal(data["minor_iov"])` | ✓ |
| 448 | `Decimal(obj["minor_iov"])` | ✓ |
| 861 | `Decimal(third_piov.minor_iov)` | ✓ |
| **883** | `Decimal(piovs[0].major_iov)` | **Bug** |
| 887 | `Decimal(piov.minor_iov)` | ✓ |

## Impact

When a new open-ended IOV is attached to a locked Global Tag (the `special_case` branch in `PayloadIOVAttachAPIView`), the adjusted neighboring IOV gets an incorrect `comb_iov`. This affects queries that filter or order by `comb_iov` (`PayloadIOVsORMMaxListAPIView`, `PayloadIOVsORMOrderByListAPIView`, etc.).

Fixes #61