### PR TITLE
Replace bare except with PayloadIOV.DoesNotExist

### DIFF
--- a/cdb_rest/views.py
+++ b/cdb_rest/views.py
@@ -146,7 +146,7 @@ class PayloadIOVDeleteAPIView(DestroyAPIView):
                 major_iov_end=self.kwargs['major_iov_end'],
                 minor_iov_end=self.kwargs['minor_iov_end']
             )
-        except:
+        except PayloadIOV.DoesNotExist:
             return None
 
     def destroy(self, request, *args, **kwargs):


### PR DESCRIPTION
Fixes #64

The `get_object` method in `PayloadIOVDetailAPIView` uses a bare `except:` that catches all exceptions. This narrows it to `PayloadIOV.DoesNotExist`, which is the only case where returning `None` is appropriate.

**Before:**
```python
except:
    return None
```

**After:**
```python
except PayloadIOV.DoesNotExist:
    return None
```