### PR TITLE
Replace bare except with PayloadIOV.DoesNotExist in get_object

### DIFF
--- a/cdb_rest/views.py
+++ b/cdb_rest/views.py
@@ -163,7 +163,7 @@ class PayloadIOVDeleteAPIView(WriteAuthMixin, DestroyAPIView):
                 major_iov_end=self.kwargs['major_iov_end'],
                 minor_iov_end=self.kwargs['minor_iov_end']
             )
-        except:
+        except PayloadIOV.DoesNotExist:
             return None
 
     def destroy(self, request, *args, **kwargs):


### PR DESCRIPTION
Fixes #64.

Recreates #65, which was auto-closed when the `master` branch was deleted during the migration to `main`. The change is rebased onto current `main`, where the same bare `except:` still exists in `PayloadIOVDeleteAPIView.get_object`.

A bare `except:` silently swallows every exception (including `KeyError`, `MultipleObjectsReturned`, or even `KeyboardInterrupt`), masking real errors as "not found". Catching `PayloadIOV.DoesNotExist` keeps the intended behavior while letting unexpected errors surface.

Django CI passes on this branch.
