### PR TITLE
Fix N+1 query in PayloadIOVBulkCreationAPIView

### DIFF
--- a/cdb_rest/views.py
+++ b/cdb_rest/views.py
@@ -460,10 +460,18 @@ class PayloadIOVBulkCreationAPIView(WriteAuthMixin, CreateAPIView):
 
     def create(self, request, *args, **kwargs):
         data = request.data
+        pl_names = {obj['payload_list'] for obj in data}
+        pl_map = {pl.name: pl for pl in PayloadList.objects.filter(name__in=pl_names)}
+        missing = pl_names - pl_map.keys()
+        if missing:
+            return Response(
+                {"detail": f"PayloadList not found: {', '.join(sorted(missing))}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         batch = [PayloadIOV(id=None, payload_url=obj["payload_url"],
                             major_iov=obj["major_iov"], minor_iov=obj["minor_iov"],
                             major_iov_end=sys.maxsize, minor_iov_end=sys.maxsize,
-                            payload_list=PayloadList.objects.get(name=obj['payload_list']),
+                            payload_list=pl_map[obj['payload_list']],
                             inserted=None,
                             comb_iov=Decimal(Decimal(obj["major_iov"]) + Decimal(obj["minor_iov"]) / 10 ** 19))
                  for obj in data]


### PR DESCRIPTION
Fixes #66.

Recreates #67, which was auto-closed when the `master` branch was deleted during the migration to `main`. The change is rebased onto current `main`, where the bulk-create endpoint still issues one `PayloadList.objects.get()` per input row.

This resolves all referenced PayloadLists in a single `filter(name__in=...)` query and reports missing ones with a 400 response listing their names, instead of an unhandled `DoesNotExist` (HTTP 500) on the first missing entry.

Django CI passes on this branch.
