### PR TITLE
Return proper HTTP status codes for client errors

### DIFF
--- a/cdb_rest/views.py
+++ b/cdb_rest/views.py
@@ -130,11 +130,11 @@ class GlobalTagDeleteAPIView(WriteAuthMixin, DestroyAPIView):
 
         gt = self.get_gtag()
         if not gt:
-            return Response({"detail": "GlobalTag %s doesn't exist" % self.kwargs['globalTagName']}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "GlobalTag %s doesn't exist" % self.kwargs['globalTagName']}, status=status.HTTP_404_NOT_FOUND)
 
         gt_status = GlobalTagStatus.objects.get(id=gt.status_id)
         if gt_status.name in ['locked', 'frozen']:
-            return Response({"detail": "Global Tag is %s." % gt_status.name}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "Global Tag is %s." % gt_status.name}, status=status.HTTP_409_CONFLICT)
         ret = self.perform_destroy(gt)
         if not ret:
             ret = {"detail": "Global tag %s deleted." % gt.name}
@@ -174,13 +174,13 @@ class PayloadIOVDeleteAPIView(WriteAuthMixin, DestroyAPIView):
 
         piov = self.get_object()
         if not piov:
-            return Response({"detail": "PayloadIOV with given parameters doesn't exist"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "PayloadIOV with given parameters doesn't exist"}, status=status.HTTP_404_NOT_FOUND)
 
         gt = GlobalTag.objects.get(name=self.kwargs['globalTagName'])
         gt_status = GlobalTagStatus.objects.get(id=gt.status_id)
 
         if gt_status.name == 'frozen':
-            return Response({"detail": "Global Tag is %s." % gt_status.name}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "Global Tag is %s." % gt_status.name}, status=status.HTTP_409_CONFLICT)
         ret = self.perform_destroy(piov)
         if not ret:
             ret = {"detail": "PayloadIOV %s deleted." % piov.payload_url}
@@ -210,10 +210,10 @@ class PayloadTypeDeleteAPIView(WriteAuthMixin, DestroyAPIView):
         ret = {}
         ptype = self.get_ptype()
         if not ptype:
-            return Response({"detail": "PayloadType %s doesn't exist" % self.kwargs['payloadTypeName']}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "PayloadType %s doesn't exist" % self.kwargs['payloadTypeName']}, status=status.HTTP_404_NOT_FOUND)
         plists = list(self.get_plists(ptype))
         if plists:
-            return Response({"detail": "PayloadType is used by %d PayloadLists" % len(plists)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "PayloadType is used by %d PayloadLists" % len(plists)}, status=status.HTTP_409_CONFLICT)
         ret = self.perform_destroy(ptype)
         if not ret:
             ret = {"detail": "Payload Type %s deleted." % ptype.name}
@@ -243,10 +243,10 @@ class PayloadListDeleteAPIView(WriteAuthMixin, DestroyAPIView):
         ret = {}
         plist = self.get_plist()
         if not plist:
-            return Response({"detail": "PayloadList %s doesn't exist" % self.kwargs['payloadListName']}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "PayloadList %s doesn't exist" % self.kwargs['payloadListName']}, status=status.HTTP_404_NOT_FOUND)
         piovs = list(self.get_piovs(plist))
         if piovs:
-            return Response({"detail": "PayloadList contains %d PayloadIOVs" % len(piovs)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "PayloadList contains %d PayloadIOVs" % len(piovs)}, status=status.HTTP_409_CONFLICT)
         ret = self.perform_destroy(plist)
         if not ret:
             ret = {"detail": "Payload Type %s deleted." % plist.name}
@@ -694,10 +694,10 @@ class PayloadListAttachAPIView(WriteAuthMixin, UpdateAPIView):
 
         gt_status = GlobalTagStatus.objects.get(id=global_tag.status_id)
         if gt_status.name == 'frozen':
-            return Response({"detail": "Global Tag is %s." % gt_status.name}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "Global Tag is %s." % gt_status.name}, status=status.HTTP_409_CONFLICT)
 
         if (PayloadList.objects.filter(global_tag=global_tag, payload_type=pl_type) and gt_status.name == 'locked'):
-            return Response({"detail": "Payload List of type %s already attached and Global Tag is locked." % pl_type}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "Payload List of type %s already attached and Global Tag is locked." % pl_type}, status=status.HTTP_409_CONFLICT)
 
         PayloadList.objects.filter(global_tag=global_tag, payload_type=pl_type).update(global_tag=None)
         p_list.global_tag = global_tag
@@ -766,7 +766,7 @@ class PayloadIOVAttachAPIView(WriteAuthMixin, UpdateAPIView):
             if gt_status.name == 'locked':
                 is_gt_locked = True
             elif gt_status.name == 'frozen':
-                return Response({"detail": "Global Tag is %s." % gt_status.name}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+                return Response({"detail": "Global Tag is %s." % gt_status.name}, status=status.HTTP_409_CONFLICT)
 
         list_piovs = PayloadIOV.objects.filter(payload_list=p_list)
 


### PR DESCRIPTION
Fixes #68.

Recreates #69, which was auto-closed when the `master` branch was deleted during the migration to `main`. Rebased onto current `main`, keeping the new immutability logic intact (e.g. the `['locked', 'frozen']` check in `GlobalTagDeleteAPIView`).

Client errors in the delete/attach paths currently return `500 Internal Server Error`. This maps them to the appropriate 4xx codes:

- missing GlobalTag / PayloadIOV / PayloadType / PayloadList → `404 Not Found`
- operations blocked by a locked/frozen GlobalTag, or by objects still in use → `409 Conflict`

Compared to the original PR, this also covers the three frozen-GlobalTag checks that were added on `main` in the meantime (`PayloadIOVDeleteAPIView.destroy`, `PayloadListAttachAPIView.put`, `PayloadIOVAttachAPIView.put`), which are the same class of client error.

Not touched here: the `except KeyError` handlers around `objects.get()` in the attach views (e.g. "PayloadList not found."), since those catch the wrong exception class and deserve a separate focused fix.

Django CI passes on this branch.
