### PR TITLE
Fix N+1 / per-row COUNT in the globalTags endpoint

### DIFF
--- a/cdb_rest/serializers.py
+++ b/cdb_rest/serializers.py
@@ -79,10 +79,16 @@ class GlobalTagListSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_payload_lists_count(obj):
-        return obj.payload_lists.count()
+        # Prefer the value annotated by the list view (one aggregate query for all rows);
+        # fall back to a per-object count for single-object callers (e.g. clone).
+        count = getattr(obj, "payload_lists_count_annotated", None)
+        return count if count is not None else obj.payload_lists.count()
 
     @staticmethod
     def get_payload_iov_count(obj):
+        count = getattr(obj, "payload_iov_count_annotated", None)
+        if count is not None:
+            return count
         return PayloadIOV.objects.filter(payload_list__in=obj.payload_lists.all()).count()
 
 

--- a/cdb_rest/views.py
+++ b/cdb_rest/views.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.db import transaction, connections
-from django.db.models import Prefetch, Q, Max
+from django.db.models import Prefetch, Q, Max, Count
 from django.forms.models import model_to_dict
 from django.shortcuts import get_object_or_404
 
@@ -261,11 +261,28 @@ class GlobalTagsListAPIView(WriteAuthMixin, ListAPIView):
     serializer_class = GlobalTagListSerializer
 
     def get_queryset(self):
-        return GlobalTag.objects.all()
+        # Annotate the PayloadList count in the same scan that fetches the GlobalTags
+        # (single multi-valued join, no fan-out). PayloadIOV counts are resolved
+        # separately below to avoid a per-row COUNT over the (very large) PayloadIOV table.
+        return GlobalTag.objects.select_related("status").annotate(
+            payload_lists_count_annotated=Count("payload_lists")
+        )
 
     def list(self, request):
-        queryset = self.get_queryset()
-        serializer = GlobalTagListSerializer(queryset, many=True)
+        global_tags = list(self.get_queryset())
+
+        # One grouped aggregate over PayloadIOV -> {global_tag_id: piov_count},
+        # instead of one COUNT query per GlobalTag (the source of the timeout on
+        # instances with tens of millions of PayloadIOVs, see issue #22).
+        piov_counts = dict(
+            PayloadIOV.objects
+            .values_list("payload_list__global_tag_id")
+            .annotate(count=Count("id"))
+        )
+        for gt in global_tags:
+            gt.payload_iov_count_annotated = piov_counts.get(gt.id, 0)
+
+        serializer = GlobalTagListSerializer(global_tags, many=True)
         return Response(serializer.data)
 
 


### PR DESCRIPTION
Fixes #22.

The `globalTags` endpoint (`GlobalTagsListAPIView` + `GlobalTagListSerializer`) computed two `SerializerMethodField`s **per GlobalTag**:

- `payload_lists_count` → `obj.payload_lists.count()`
- `payload_iov_count` → `PayloadIOV.objects.filter(payload_list__in=obj.payload_lists.all()).count()`

That is `1 + 3*N` queries, and — the actual cause of the reported timeout — **one COUNT over the full PayloadIOV table per GlobalTag**. On an instance with ~36M PayloadIOVs the endpoint times out after a minute, while the raw-SQL `payloadiovs` endpoint stays fast (as noted in the issue).

This resolves both counts up front:
- `payload_lists_count` is annotated in the GlobalTag scan (single multi-valued join, no fan-out);
- `payload_iov_count` for all GTs comes from **one grouped aggregate** over PayloadIOV (`values_list('payload_list__global_tag_id') + Count('id')`), mapped back onto the instances.

The endpoint now runs in **2 queries regardless of GlobalTag count**. The serializer reads the annotated values and falls back to the previous per-object counts when they are absent, so single-object callers (e.g. the clone view) are unchanged. The JSON output is identical.

Verified locally on SQLite: with 8 GlobalTags the endpoint drops from 25 to 2 queries with identical counts, and the fallback path stays correct on edge cases (a GlobalTag with no PayloadLists, a PayloadList with no PayloadIOVs).

Side note (not changed here): `GlobalTagListSerializer` still declares a `type` field that no longer exists on the `GlobalTag` model; DRF silently drops it. Happy to remove it in a separate PR.
