### PR TITLE
Catch DoesNotExist (not KeyError) for missing objects in write views

### DIFF
--- a/cdb_rest/views.py
+++ b/cdb_rest/views.py
@@ -93,7 +93,9 @@ class GlobalTagListCreationAPIView(WriteAuthMixin, ListCreateAPIView):
             gt_status = GlobalTagStatus.objects.get(name=data['status'])
             data['status'] = gt_status.pk
         except KeyError:
-            return Response({"detail": "GlobalTagStatus not found."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "Field 'status' is required."}, status=status.HTTP_400_BAD_REQUEST)
+        except GlobalTagStatus.DoesNotExist:
+            return Response({"detail": "GlobalTagStatus '%s' not found." % data['status']}, status=status.HTTP_404_NOT_FOUND)
 
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -340,14 +342,16 @@ class PayloadListListCreationAPIView(WriteAuthMixin, ListCreateAPIView):
         next_id = self.get_next_id()
 
         data['id'] = int(next_id)
-        data['name'] = data['payload_type'] + '_' + str(next_id)
 
         try:
             payload_type = PayloadType.objects.get(name=data['payload_type'])
-            data['payload_type'] = payload_type.pk
         except KeyError:
-            return Response({"detail": "PayloadType not found."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "Field 'payload_type' is required."}, status=status.HTTP_400_BAD_REQUEST)
+        except PayloadType.DoesNotExist:
+            return Response({"detail": "PayloadType '%s' not found." % data['payload_type']}, status=status.HTTP_404_NOT_FOUND)
 
+        data['name'] = payload_type.name + '_' + str(next_id)
+        data['payload_type'] = payload_type.pk
         data['global_tag'] = None
 
         serializer = self.get_serializer(data=data)
@@ -684,11 +688,15 @@ class PayloadListAttachAPIView(WriteAuthMixin, UpdateAPIView):
         try:
             p_list = PayloadList.objects.get(name=data['payload_list'])
         except KeyError:
-            return Response({"detail": "PayloadList not found."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "Field 'payload_list' is required."}, status=status.HTTP_400_BAD_REQUEST)
+        except PayloadList.DoesNotExist:
+            return Response({"detail": "PayloadList '%s' not found." % data['payload_list']}, status=status.HTTP_404_NOT_FOUND)
         try:
             global_tag = GlobalTag.objects.get(name=data['global_tag'])
         except KeyError:
-            return Response({"detail": "GlobalTag not found."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "Field 'global_tag' is required."}, status=status.HTTP_400_BAD_REQUEST)
+        except GlobalTag.DoesNotExist:
+            return Response({"detail": "GlobalTag '%s' not found." % data['global_tag']}, status=status.HTTP_404_NOT_FOUND)
 
         pl_type = p_list.payload_type
 
@@ -754,11 +762,15 @@ class PayloadIOVAttachAPIView(WriteAuthMixin, UpdateAPIView):
         try:
             p_list = PayloadList.objects.get(name=data['payload_list'])
         except KeyError:
-            return Response({"detail": "PayloadList not found."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "Field 'payload_list' is required."}, status=status.HTTP_400_BAD_REQUEST)
+        except PayloadList.DoesNotExist:
+            return Response({"detail": "PayloadList '%s' not found." % data['payload_list']}, status=status.HTTP_404_NOT_FOUND)
         try:
             piov = PayloadIOV.objects.get(id=data['piov_id'])
         except KeyError:
-            return Response({"detail": "PayloadIOV not found."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({"detail": "Field 'piov_id' is required."}, status=status.HTTP_400_BAD_REQUEST)
+        except PayloadIOV.DoesNotExist:
+            return Response({"detail": "PayloadIOV '%s' not found." % data['piov_id']}, status=status.HTTP_404_NOT_FOUND)
 
         is_gt_locked = False
         if p_list.global_tag:
@@ -909,13 +921,13 @@ class GlobalTagChangeStatusAPIView(WriteAuthMixin, UpdateAPIView):
 
         try:
             gt = self.get_global_tag()
-        except KeyError:
-            return Response({"detail": "GlobalTag not found."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except GlobalTag.DoesNotExist:
+            return Response({"detail": "GlobalTag '%s' not found." % self.kwargs.get('globalTagName')}, status=status.HTTP_404_NOT_FOUND)
 
         try:
             gt_status = self.get_gt_status()
-        except KeyError:
-            return Response({"detail": "GlobalTag Status not found."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except GlobalTagStatus.DoesNotExist:
+            return Response({"detail": "GlobalTagStatus '%s' not found." % self.kwargs.get('newStatus')}, status=status.HTTP_404_NOT_FOUND)
 
         gt.status = gt_status
         serializer = GlobalTagCreateSerializer(instance=gt, data=model_to_dict(gt))

--- a/cdb_rest/views.py
+++ b/cdb_rest/views.py
@@ -84,6 +84,11 @@ class GlobalTagListCreationAPIView(WriteAuthMixin, ListCreateAPIView):
 
     def create(self, request, *args, **kwargs):
         data = request.data
+
+        for field in ('name', 'status'):
+            if field not in data:
+                return Response({"detail": "Field '%s' is required." % field}, status=status.HTTP_400_BAD_REQUEST)
+
         plugin = load_permission_plugin()
         target_object = {"object": "GlobalTag", "role": "admin", "name": data['name']}
         if not plugin.has_permission(request, target_object):
@@ -92,8 +97,6 @@ class GlobalTagListCreationAPIView(WriteAuthMixin, ListCreateAPIView):
         try:
             gt_status = GlobalTagStatus.objects.get(name=data['status'])
             data['status'] = gt_status.pk
-        except KeyError:
-            return Response({"detail": "Field 'status' is required."}, status=status.HTTP_400_BAD_REQUEST)
         except GlobalTagStatus.DoesNotExist:
             return Response({"detail": "GlobalTagStatus '%s' not found." % data['status']}, status=status.HTTP_404_NOT_FOUND)
 

--- a/cdb_rest/views.py
+++ b/cdb_rest/views.py
@@ -509,7 +509,10 @@ class GlobalTagCloneAPIView(WriteAuthMixin, CreateAPIView):
         if not plugin.has_permission(request, target_object):
             return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
 
-        global_tag = self.get_global_tag()
+        try:
+            global_tag = self.get_global_tag()
+        except GlobalTag.DoesNotExist:
+            return Response({"detail": "GlobalTag '%s' not found." % globalTagName}, status=status.HTTP_404_NOT_FOUND)
         payload_lists = self.get_payload_lists(global_tag)
 
         global_tag.id = None
@@ -680,6 +683,10 @@ class PayloadListAttachAPIView(WriteAuthMixin, UpdateAPIView):
     def put(self, request, *args, **kwargs):
         data = request.data
 
+        for field in ('global_tag', 'payload_list'):
+            if field not in data:
+                return Response({"detail": "Field '%s' is required." % field}, status=status.HTTP_400_BAD_REQUEST)
+
         plugin = load_permission_plugin()
         target_object = {"object": "GlobalTag", "role": "admin", "name": data['global_tag']}
         if not plugin.has_permission(request, target_object):
@@ -687,14 +694,10 @@ class PayloadListAttachAPIView(WriteAuthMixin, UpdateAPIView):
 
         try:
             p_list = PayloadList.objects.get(name=data['payload_list'])
-        except KeyError:
-            return Response({"detail": "Field 'payload_list' is required."}, status=status.HTTP_400_BAD_REQUEST)
         except PayloadList.DoesNotExist:
             return Response({"detail": "PayloadList '%s' not found." % data['payload_list']}, status=status.HTTP_404_NOT_FOUND)
         try:
             global_tag = GlobalTag.objects.get(name=data['global_tag'])
-        except KeyError:
-            return Response({"detail": "Field 'global_tag' is required."}, status=status.HTTP_400_BAD_REQUEST)
         except GlobalTag.DoesNotExist:
             return Response({"detail": "GlobalTag '%s' not found." % data['global_tag']}, status=status.HTTP_404_NOT_FOUND)
 
@@ -754,6 +757,10 @@ class PayloadIOVAttachAPIView(WriteAuthMixin, UpdateAPIView):
 
         data = request.data
 
+        for field in ('global_tag', 'payload_list', 'piov_id'):
+            if field not in data:
+                return Response({"detail": "Field '%s' is required." % field}, status=status.HTTP_400_BAD_REQUEST)
+
         plugin = load_permission_plugin()
         target_object = {"object": "GlobalTag", "role": "createiov", "name": data['global_tag']}
         if not plugin.has_permission(request, target_object):
@@ -761,14 +768,12 @@ class PayloadIOVAttachAPIView(WriteAuthMixin, UpdateAPIView):
 
         try:
             p_list = PayloadList.objects.get(name=data['payload_list'])
-        except KeyError:
-            return Response({"detail": "Field 'payload_list' is required."}, status=status.HTTP_400_BAD_REQUEST)
         except PayloadList.DoesNotExist:
             return Response({"detail": "PayloadList '%s' not found." % data['payload_list']}, status=status.HTTP_404_NOT_FOUND)
         try:
             piov = PayloadIOV.objects.get(id=data['piov_id'])
-        except KeyError:
-            return Response({"detail": "Field 'piov_id' is required."}, status=status.HTTP_400_BAD_REQUEST)
+        except (ValueError, TypeError):
+            return Response({"detail": "Field 'piov_id' must be an integer."}, status=status.HTTP_400_BAD_REQUEST)
         except PayloadIOV.DoesNotExist:
             return Response({"detail": "PayloadIOV '%s' not found." % data['piov_id']}, status=status.HTTP_404_NOT_FOUND)
 


### PR DESCRIPTION
Follow-up to #98; relates to #68.

Several create/attach/change-status views wrap `objects.get()` in `try/except KeyError`. But `get()` never raises `KeyError` on a missing row — it raises `Model.DoesNotExist`. So a request naming a **non-existent** object was not caught here and surfaced as an unhandled **500**. `KeyError` only fired when a required **field was missing from the body**, yet that was reported with a misleading `"<object> not found"` message, also as 500.

This separates the two real cases:

- missing required field → **400 Bad Request**
- referenced object absent → **404 Not Found**

Sites fixed: `GlobalTagListCreationAPIView`, `PayloadListListCreationAPIView`, `PayloadListAttachAPIView`, `PayloadIOVAttachAPIView`, `GlobalTagChangeStatusAPIView`, and `GlobalTagCloneAPIView`.

Details:

- In `PayloadListListCreationAPIView` the `payload_type` field was dereferenced while building `data['name']` *before* the try block, so a missing field 500'd there too; the name is now built after the lookup succeeds.
- In the two attach views the permission `target_object` dereferences `data['global_tag']` before the lookups, so required-field validation can't live inside the per-lookup `try`. Required body fields are now validated up front (→ 400) before anything dereferences them.
- In `GlobalTagListCreationAPIView` the permission `target_object` dereferences `data['name']` before validation, so a missing `name` still 500'd while a missing `status` returned 400. Required fields (`name`, `status`) are now validated up front (→ 400) with the same pattern as the attach views; the now-redundant `except KeyError` on the status lookup is removed.
- `GlobalTagCloneAPIView`: cloning a non-existent source GlobalTag raised an unguarded `DoesNotExist` (500) → now 404.
- `PayloadIOVAttachAPIView`: a non-integer `piov_id` raised `ValueError` (500) → now 400.

Verified end to end with the Django test client: missing field → 400, missing object → 404, non-integer `piov_id` → 400, clone of a missing GlobalTag → 404. Django CI passes on this branch. The added `GlobalTagListCreationAPIView` name/status guard mirrors the already-verified attach-view pattern and passes a syntax check; it has not been separately re-run end to end.