### PR TITLE
Add optional duration parameter to the timeout endpoint

### DIFF
--- a/cdb_rest/urls.py
+++ b/cdb_rest/urls.py
@@ -48,5 +48,6 @@ urlpatterns = [
     path('payloadiovs/', PayloadIOVsSQLListAPIView.as_view(), name="payloadiovs"),
     path('user_settings/<str:name>/', CDBSettingAPIView.as_view()),
     path('timeout', TimeoutListAPIView.as_view(), name="timeout"),
+    path('timeout/<int:seconds>', TimeoutListAPIView.as_view(), name="timeout_seconds"),
 
 ]

--- a/cdb_rest/views.py
+++ b/cdb_rest/views.py
@@ -63,10 +63,22 @@ class GlobalTagByNameDetailAPIView(WriteAuthMixin, RetrieveAPIView):
 
 
 class TimeoutListAPIView(WriteAuthMixin, ListAPIView):
-    """Test endpoint that simulates a long-running request (30 min timeout)."""
+    """Test endpoint that simulates a long-running request by sleeping.
 
-    def list(self, request):
-        time.sleep(1800)
+    Accepts an optional duration in seconds (``/timeout/<seconds>``), clamped
+    to ``MAX_TIMEOUT_SECONDS`` so a caller cannot hold a worker indefinitely.
+    Without a parameter it falls back to ``DEFAULT_TIMEOUT_SECONDS``.
+    """
+
+    DEFAULT_TIMEOUT_SECONDS = 1800
+    MAX_TIMEOUT_SECONDS = 1800
+
+    def list(self, request, *args, **kwargs):
+        seconds = self.kwargs.get('seconds')
+        if seconds is None:
+            seconds = self.DEFAULT_TIMEOUT_SECONDS
+        seconds = min(seconds, self.MAX_TIMEOUT_SECONDS)
+        time.sleep(seconds)
         return Response()
 
 


### PR DESCRIPTION
Fixes #24.

Adds a `/timeout/<int:seconds>` route so the timeout test endpoint can sleep for a caller-specified duration instead of a hard-coded 1800s. The value is clamped to `MAX_TIMEOUT_SECONDS` (kept at the previous 1800s) so a request can never hold a worker longer than before — the "top limit should be protected" point from the issue.

The bare `/timeout` route is preserved and still uses the default duration, so existing callers are unaffected. The `<int:...>` path converter already rejects negative and non-numeric input.

Verified locally: `/timeout` → 1800s, `/timeout/5` → 5s, `/timeout/999999` → clamped to 1800s. Django CI passes on this branch.
