### PR TITLE
Fix documentation CI: pin Sphinx <8 and target main

### DIFF
--- a/.github/workflows/build-deploy-documentation.yml
+++ b/.github/workflows/build-deploy-documentation.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-pages:
@@ -50,5 +50,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        # Deploy only if the branch is master
-        if: github.ref == 'refs/heads/master'
+        # Deploy only if the branch is main
+        if: github.ref == 'refs/heads/main'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -143,7 +143,7 @@ html_theme_options = {
     "use_edit_page_button": True,
     "use_download_button": True,
     "path_to_docs": "docs/source/",
-    "repository_branch": "master",
+    "repository_branch": "main",
     "logo": {
         "image_light": "_static/HSFLogo.png",
         "image_dark": "_static/HSFLogo.png",
@@ -310,7 +310,7 @@ html_context = {
     "github_url": "https://github.com/BNLNPPS/nopayloaddb",
     "github_user": "BNLNPPS",
     "github_repo": "nopayloaddb",
-    "github_version": "master",
+    "github_version": "main",
     "doc_path": "docs/source",
     
     # Version information

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -243,7 +243,7 @@ See our :doc:`development` guide for details.
 
 **License**
 
-See the `LICENSE <https://github.com/BNLNPPS/nopayloaddb/blob/master/LICENSE>`_.
+See the `LICENSE <https://github.com/BNLNPPS/nopayloaddb/blob/main/LICENSE>`_.
 
 
 Acknowledgments

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ pytz==2023.3
 sqlparse==0.4.3
 typing_extensions==4.5.0
 # Documentation
+# Cap Sphinx below 8: 8.x imports typing_extensions.TypeAliasType, which the
+# pinned typing_extensions==4.5.0 does not provide, breaking `make html`.
+Sphinx>=7.4,<8
 sphinx_book_theme>=1.1
 sphinxcontrib-django==2.5
 sphinxcontrib-httpdomain


### PR DESCRIPTION
The **Documentation** workflow's `build-pages` job has been failing on every PR for weeks (including recent same-repo PRs), unrelated to the changes under review.

**Cause.** `requirements.txt` leaves `Sphinx` unpinned, so on the CI Python (3.11) it resolves to 8.x/9.x. Those versions' `sphinx/util/typing.py` reference `typing_extensions.TypeAliasType`, which the pinned `typing_extensions==4.5.0` does not provide, so `make html` aborts with:

```
AttributeError: module 'typing_extensions' has no attribute 'TypeAliasType'
make: *** [Makefile:19: html] Error 1
```

**Fix.** Pin `Sphinx>=7.4,<8` — the newest line compatible with the currently pinned doc extensions and `typing_extensions`. Verified locally: a clean `make html` succeeds and produces `build/html` (Sphinx 7.4.7).

While here, the workflow still referenced the deleted `master` branch (the `push` trigger and the `deploy-page` gate `if: github.ref == 'refs/heads/master'`), so docs were never deployed after the rename — retargeted both to `main`.
