### PR TITLE
Use ubuntu-22.04 for functional tests (ubuntu-20.04 retired)

### DIFF
--- a/.github/workflows/backend-client-functional-tests.yml
+++ b/.github/workflows/backend-client-functional-tests.yml
@@ -2,7 +2,7 @@ on:
   - pull_request
 jobs:
     Backend-Client-Functional-Tests-CI:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - name: Check out the commit that triggered this job
               uses: actions/checkout@v3


### PR DESCRIPTION
The `Backend-Client-Functional-Tests-CI` job pins `runs-on: ubuntu-20.04`. GitHub Actions has retired that hosted runner image, so the job is never scheduled and sits in `queued` indefinitely (visible as a perpetually pending check on open PRs).

Bump the label to `ubuntu-22.04` so the job runs again.

`ubuntu-22.04` is deliberate — not `ubuntu-latest`. The job calls the v1 `docker-compose` binary (`docker-compose up`, `docker-compose logs`), which the `ubuntu-24.04` image (where `ubuntu-latest` now points) no longer ships; only the Compose v2 plugin (`docker compose`) is present there. `ubuntu-22.04` still provides `docker-compose` v1, so this keeps the workflow working without also having to migrate to Compose v2. Migrating the compose calls to `docker compose` v2 and then moving to `ubuntu-latest` is a reasonable follow-up, out of scope here.

Note: this only unblocks scheduling. The job also checks out a private client repo via `secrets.my_token`, which isn't available to pull requests from forks, so that step still can't pass on fork PRs (including this one); it is unaffected for same-repo PRs.
