### PR TITLE
Remove dead 'type' field from GlobalTagListSerializer

### DIFF
--- a/cdb_rest/serializers.py
+++ b/cdb_rest/serializers.py
@@ -71,11 +71,10 @@ class GlobalTagListSerializer(serializers.ModelSerializer):
     payload_lists_count = serializers.SerializerMethodField()
     payload_iov_count = serializers.SerializerMethodField()
     status = serializers.SlugRelatedField(slug_field="name", read_only=True)
-    type = serializers.SlugRelatedField(slug_field="name", read_only=True)
 
     class Meta:
         model = GlobalTag
-        fields = ("id", "name", "author", "status", "type", "payload_lists_count", "payload_iov_count", "created", "updated")
+        fields = ("id", "name", "author", "status", "payload_lists_count", "payload_iov_count", "created", "updated")
 
     @staticmethod
     def get_payload_lists_count(obj):


### PR DESCRIPTION
Relates to #15 (the GlobalTagType half).

`GlobalTag` lost its `type` relation when `GlobalTagType` was removed, but `GlobalTagListSerializer` still declares a `type` `SlugRelatedField` and lists `"type"` in `Meta.fields`. Since the instance has no `type` attribute, DRF silently drops it — it never appears in responses, so this is purely misleading dead code.

Removing the field and its `Meta.fields` entry. Serializer output is unchanged (verified: the serialized keys are identical before and after, `type` was already absent).

This is the small, safe slice of #15. The other half (removing `GlobalTagStatus`) is a much larger, semantic change — `GlobalTagStatus` is still live and referenced throughout the write/immutability logic — so it's intentionally out of scope here.
