### PR TITLE
docs: fix stale master references and globalTags response example

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -105,9 +105,11 @@ List All Global Tags
           "id": 1,
           "name": "sPHENIX_ExampleGT_24",
           "author": "admin",
-          "description": "Example global tag for sPHENIX",
-          "status": 1,
-          "created": "2022-02-21T15:10:00.000000Z"
+          "status": "unlocked",
+          "payload_lists_count": 3,
+          "payload_iov_count": 128,
+          "created": "2022-02-21T15:10:00.000000Z",
+          "updated": "2022-02-21T15:10:00.000000Z"
         }
       ]
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -918,7 +918,7 @@ Git Workflow
 
 **Branch Strategy**
 
-- ``master``: Main development branch
+- ``main``: Main development branch
 - ``feature/feature-name``: Feature development
 - ``bugfix/bug-description``: Bug fixes
 - ``hotfix/urgent-fix``: Production hotfixes
@@ -937,7 +937,7 @@ Git Workflow
 
 **Pull Request Process**
 
-1. Create feature branch from master
+1. Create feature branch from main
 2. Make changes with appropriate tests
 3. Ensure all tests pass
 4. Update documentation if needed


### PR DESCRIPTION
## Summary

Two small, self-contained documentation corrections found while reviewing the docs:

1. **Branch references**: `docs/source/development.rst` still instructed contributors to use a `master` branch in two places (Branch Strategy and Pull Request Process). The repository's default branch is `main`, so these are updated to match.

2. **`GET /globalTags` example response**: the example did not match what `GlobalTagListSerializer` actually returns. It has been corrected to:
   - drop the `description` field (not part of the serializer output),
   - render `status` as its name string (e.g. `"unlocked"`) instead of an integer id, since the serializer uses a `SlugRelatedField(slug_field="name")`,
   - add the `payload_lists_count`, `payload_iov_count` and `updated` fields that the endpoint actually returns.

## Notes

Documentation-only change; no code or behavior is affected. Scope is intentionally limited to the `globalTags` list example (whose fields are explicitly declared in the serializer and thus verifiable); other endpoint examples that rely on nested `depth=1` output were left untouched.