### PR TITLE
ci: bump actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/backend-client-functional-tests.yml
+++ b/.github/workflows/backend-client-functional-tests.yml
@@ -5,7 +5,7 @@ jobs:
         runs-on: ubuntu-20.04
         steps:
             - name: Check out the commit that triggered this job
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                 path: ${{ github.event.repository.name }}
 
@@ -15,7 +15,7 @@ jobs:
                   docker-compose up --build -d
 
             - name: Check out client-side repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: ligerlac/nopayloadclient
                   token: ${{ secrets.my_token }}

--- a/.github/workflows/django_functional_tests.yml
+++ b/.github/workflows/django_functional_tests.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt-get install -y postgresql-client
       - name: Test PostgreSQL Connection
         run: psql "host=localhost user=login dbname=dbname password=password"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: nopayloaddb
       - name: Install Dependencies


### PR DESCRIPTION
## Summary

Bumps `actions/checkout` from `v3` to `v4` in the two workflows still pinned to v3:

- `.github/workflows/django_functional_tests.yml`
- `.github/workflows/backend-client-functional-tests.yml`

This aligns them with `docker-release.yml` and `build-deploy-documentation.yml`, which already use `@v4`. `actions/checkout@v3` runs on the deprecated Node 16 runtime; v4 moves to Node 20.

## Notes

CI-only change, no functional impact. Intentionally scoped to the checkout version only — the separate `ubuntu-20.04 -> ubuntu-22.04` runner fix for `backend-client-functional-tests.yml` is handled in #103.