### PR TITLE
Optimize globalTags counts and remove dead field from GlobalTagListSerializer

### DIFF
--- a/cdb_rest/serializers.py
+++ b/cdb_rest/serializers.py
@@ -79,10 +79,16 @@ class GlobalTagListSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_payload_lists_count(obj):
-        return obj.payload_lists.count()
+        # Prefer the value annotated by the list view (one aggregate query for all rows);
+        # fall back to a per-object count for single-object callers (e.g. clone).
+        count = getattr(obj, "payload_lists_count_annotated", None)
+        return count if count is not None else obj.payload_lists.count()
 
     @staticmethod
     def get_payload_iov_count(obj):
+        count = getattr(obj, "payload_iov_count_annotated", None)
+        if count is not None:
+            return count
         return PayloadIOV.objects.filter(payload_list__in=obj.payload_lists.all()).count()
 
 

--- a/cdb_rest/serializers.py
+++ b/cdb_rest/serializers.py
@@ -71,11 +71,10 @@ class GlobalTagListSerializer(serializers.ModelSerializer):
     payload_lists_count = serializers.SerializerMethodField()
     payload_iov_count = serializers.SerializerMethodField()
     status = serializers.SlugRelatedField(slug_field="name", read_only=True)
-    type = serializers.SlugRelatedField(slug_field="name", read_only=True)
 
     class Meta:
         model = GlobalTag
-        fields = ("id", "name", "author", "status", "type", "payload_lists_count", "payload_iov_count", "created", "updated")
+        fields = ("id", "name", "author", "status", "payload_lists_count", "payload_iov_count", "created", "updated")
 
     @staticmethod
     def get_payload_lists_count(obj):

--- a/cdb_rest/views.py
+++ b/cdb_rest/views.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.db import transaction, connections
-from django.db.models import Prefetch, Q, Max
+from django.db.models import Prefetch, Q, Max, Count
 from django.forms.models import model_to_dict
 from django.shortcuts import get_object_or_404
 
@@ -261,11 +261,28 @@ class GlobalTagsListAPIView(WriteAuthMixin, ListAPIView):
     serializer_class = GlobalTagListSerializer
 
     def get_queryset(self):
-        return GlobalTag.objects.all()
+        # Annotate the PayloadList count in the same scan that fetches the GlobalTags
+        # (single multi-valued join, no fan-out). PayloadIOV counts are resolved
+        # separately below to avoid a per-row COUNT over the (very large) PayloadIOV table.
+        return GlobalTag.objects.select_related("status").annotate(
+            payload_lists_count_annotated=Count("payload_lists")
+        )
 
     def list(self, request):
-        queryset = self.get_queryset()
-        serializer = GlobalTagListSerializer(queryset, many=True)
+        global_tags = list(self.get_queryset())
+
+        # One grouped aggregate over PayloadIOV -> {global_tag_id: piov_count},
+        # instead of one COUNT query per GlobalTag (the source of the timeout on
+        # instances with tens of millions of PayloadIOVs, see issue #22).
+        piov_counts = dict(
+            PayloadIOV.objects
+            .values_list("payload_list__global_tag_id")
+            .annotate(count=Count("id"))
+        )
+        for gt in global_tags:
+            gt.payload_iov_count_annotated = piov_counts.get(gt.id, 0)
+
+        serializer = GlobalTagListSerializer(global_tags, many=True)
         return Response(serializer.data)
 
 


### PR DESCRIPTION
## Summary

Two related changes to the `globalTags` endpoint and its serializer.

**1. Fix N+1 / per-row COUNT (was PR #99; fixes #22)**
`GlobalTagsListAPIView` computed `payload_lists_count` and `payload_iov_count` per row, so listing N global tags ran `1 + 3N` queries. The counts are now resolved in two aggregate queries for the whole result set:
- `payload_lists_count` via `annotate(Count(...))` (a LEFT JOIN, so tags with zero payload lists are kept, not dropped),
- `payload_iov_count` via a single grouped aggregate mapped back onto each tag in Python.

The serializer reads the annotated values when present and falls back to a per-object count for single-object callers (for example the clone view), so behavior and output are unchanged.

**2. Remove dead `type` field (was PR #104)**
`GlobalTagListSerializer` declared a `type = SlugRelatedField(...)` that maps to no attribute on `GlobalTag`. DRF silently skips it (`read_only` -> `SkipField`), so it was never part of the response. Removing it is not an API change; it is dead-code cleanup.

## Notes

Supersedes #99 and #104 (both touch `GlobalTagListSerializer`; merged here to avoid a needless "update branch" step between them). Output of the endpoint is unchanged. `python -m py_compile` passes.