### PR TITLE
CI: modernize functional-test workflows (runner + checkout)

### DIFF
--- a/.github/workflows/backend-client-functional-tests.yml
+++ b/.github/workflows/backend-client-functional-tests.yml
@@ -2,7 +2,7 @@ on:
   - pull_request
 jobs:
     Backend-Client-Functional-Tests-CI:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - name: Check out the commit that triggered this job
               uses: actions/checkout@v3

--- a/.github/workflows/backend-client-functional-tests.yml
+++ b/.github/workflows/backend-client-functional-tests.yml
@@ -5,7 +5,7 @@ jobs:
         runs-on: ubuntu-22.04
         steps:
             - name: Check out the commit that triggered this job
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                 path: ${{ github.event.repository.name }}
 
@@ -15,7 +15,7 @@ jobs:
                   docker-compose up --build -d
 
             - name: Check out client-side repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   repository: ligerlac/nopayloadclient
                   token: ${{ secrets.my_token }}

--- a/.github/workflows/django_functional_tests.yml
+++ b/.github/workflows/django_functional_tests.yml
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt-get install -y postgresql-client
       - name: Test PostgreSQL Connection
         run: psql "host=localhost user=login dbname=dbname password=password"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: nopayloaddb
       - name: Install Dependencies


### PR DESCRIPTION
## Summary

Two small CI updates to the functional-test workflows, grouped because they touch the same files.

**1. Runner bump (was PR #103)**
`backend-client-functional-tests.yml` used `ubuntu-20.04`, which GitHub has retired, so the job could no longer be scheduled. It now runs on `ubuntu-22.04`. `22.04` is chosen over `ubuntu-latest` because the job uses Compose v1 (`docker-compose`), which is not present on the `ubuntu-24.04` image behind `ubuntu-latest`.

**2. checkout bump (was PR #107)**
`actions/checkout` is bumped from `v3` to `v4` in `backend-client-functional-tests.yml` and `django_functional_tests.yml`, aligning them with the other workflows already on `v4`. `checkout@v3` runs on the deprecated Node 16 runtime.

## Notes

Supersedes #103 and #107 (both edit the functional-test workflows; merged here to avoid a needless "update branch" step between them). CI-only, no functional impact.