### PR TITLE
Updating API documentation with the most recent changes

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -42,14 +42,14 @@ Verify your installation with this simple command:
 
 **Response Formats**
 
-All API responses use JSON format. Successful responses include appropriate HTTP status codes:
+All API responses use JSON format. Successful write operations (POST, PUT, DELETE)
+return ``200 OK`` with a JSON body. Other HTTP status codes indicate errors:
 
-- ``200 OK`` - Successful GET request
-- ``201 Created`` - Successful POST request (resource created)
-- ``204 No Content`` - Successful DELETE request
-- ``400 Bad Request`` - Invalid request data
-- ``404 Not Found`` - Resource not found
-- ``500 Internal Server Error`` - Server error
+- ``200 OK`` - Successful request, including creates and deletes
+- ``400 Bad Request`` - Invalid request data (serializer validation errors)
+- ``403 Forbidden`` - Rejected by the configured permission plugin
+- ``404 Not Found`` - Resource not found (lookups by ID/name, unknown settings)
+- ``500 Internal Server Error`` - Business-logic errors (missing referenced resources, locked/frozen global tags, IOV conflicts) and unhandled server errors
 
 Authentication
 ==============
@@ -87,6 +87,73 @@ configured via the ``CDB_PERMISSION_PLUGIN_CLASS`` environment variable:
   regular expressions matched against the target global tag or payload list name
 
 
+.. _browse-mode:
+
+Pagination, Search and Sorting
+==============================
+
+The main list endpoints — ``global-tags``, ``payload-types``, ``payload-lists`` and
+``payload-iovs`` — return plain, unpaginated JSON arrays by default. Passing a ``page``
+query parameter switches them into a paginated *browse mode* with server-side search,
+sorting and filtering:
+
+:query page: Page number, 1-based. The presence of this parameter enables browse mode
+:query page_size: Items per page, 1–1000 (default ``25``)
+:query search: Case-insensitive substring search
+:query sort: Sort field (whitelisted per endpoint; unknown values fall back to the default)
+:query order: ``asc`` (default) or ``desc``
+
+Additional filters per endpoint:
+
+.. list-table::
+   :widths: 25 30 45
+   :header-rows: 1
+
+   * - Endpoint
+     - Filters
+     - Search fields
+   * - ``global-tags``
+     - ``status``
+     - ``name``, ``author``
+   * - ``payload-types``
+     - —
+     - ``name``
+   * - ``payload-lists``
+     - ``global_tag``, ``payload_type``
+     - ``name``, ``global_tag__name``, ``payload_type__name``
+   * - ``payload-iovs``
+     - ``payload_list``, ``global_tag``, ``payload_type``
+     - ``payload_url``, ``payload_list__name``
+
+**Example Request:**
+
+.. code-block:: bash
+
+   curl 'http://localhost:8000/api/cdb_rest/global-tags?page=1&page_size=2&sort=created&order=desc'
+
+**Example Response:**
+
+.. code-block:: json
+
+   {
+     "count": 2,
+     "page": 1,
+     "page_size": 2,
+     "total_pages": 1,
+     "results": [
+       {
+         "id": 1,
+         "name": "MyNewGT_v1.0",
+         "author": "researcher",
+         "status": "unlocked",
+         "payload_lists_count": 1,
+         "payload_iov_count": 2,
+         "created": "2026-07-23T00:00:26.714171",
+         "updated": "2026-07-23T00:05:32.399958"
+       }
+     ]
+   }
+
 Global Tag Endpoints
 ====================
 
@@ -107,6 +174,8 @@ List All Global Tags
 
       curl http://localhost:8000/api/cdb_rest/global-tags
 
+   Supports :ref:`browse mode <browse-mode>` via ``?page=``, with a ``status`` filter.
+
    **Example Response:**
 
    .. code-block:: json
@@ -116,23 +185,34 @@ List All Global Tags
           "id": 1,
           "name": "sPHENIX_ExampleGT_24",
           "author": "admin",
-          "description": "Example global tag for sPHENIX",
-          "status": 1,
-          "created": "2022-02-21T15:10:00.000000Z"
+          "status": "unlocked",
+          "payload_lists_count": 1,
+          "payload_iov_count": 2,
+          "created": "2022-02-21T15:10:00.000000",
+          "updated": "2022-02-21T15:10:00.000000"
         }
       ]
+
+   .. note::
+      The legacy ``GET /api/cdb_rest/gt`` endpoint also lists all global tags, but
+      returns the full nested representation (same shape as *Get Global Tag by Name*)
+      for every tag, which can be very large.
 
 Get Global Tag by Name
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. http:get:: /api/cdb_rest/global-tags/(str:name)
 
-   Retrieve detailed information about a specific global tag.
+   Retrieve detailed information about a specific global tag, including all payload
+   lists and their payload IOVs fully nested.
 
    **Alias of:** ``GET /api/cdb_rest/globalTag/(str:name)`` (legacy path)
 
    :param name: Global tag name
    :type name: string
+   :query light: If present (e.g. ``?light=1``), return metadata only — no nested
+      payload lists, but ``payload_lists_count`` and ``payload_iov_count`` computed
+      in the database (same shape as the list endpoint)
 
    **Example Request:**
 
@@ -148,17 +228,40 @@ Get Global Tag by Name
         "id": 1,
         "name": "sPHENIX_ExampleGT_24",
         "author": "admin",
-        "description": "Example global tag for sPHENIX experiment",
-        "status": 1,
-        "created": "2022-02-21T15:10:00.000000Z",
+        "status": {
+          "id": 1,
+          "name": "unlocked",
+          "description": null,
+          "created": "2022-02-21T15:00:00.000000"
+        },
         "payload_lists": [
           {
             "id": 210,
             "name": "Beam_210",
-            "payload_type": "Beam"
+            "global_tag": "sPHENIX_ExampleGT_24",
+            "payload_type": "Beam",
+            "payload_iov": [
+              {
+                "id": 1,
+                "payload_url": "D0DXMagnets.dat",
+                "checksum": "e99a18c428cb38d5f260853678922e03",
+                "major_iov": 0,
+                "minor_iov": 0,
+                "comb_iov": "0.0000000000000000000",
+                "major_iov_end": 9223372036854775807,
+                "minor_iov_end": 9223372036854775807,
+                "payload_list": "Beam_210",
+                "inserted": "2022-02-21T15:10:00.000000"
+              }
+            ],
+            "created": "2022-02-21T15:10:00.000000"
           }
-        ]
+        ],
+        "created": "2022-02-21T15:10:00.000000",
+        "updated": "2022-02-21T15:10:00.000000"
       }
+
+   Unknown names return ``404`` with ``{"detail": "Not found."}``.
 
 Create Global Tag
 ~~~~~~~~~~~~~~~~~
@@ -186,7 +289,7 @@ Create Global Tag
           "status": "unlocked"
         }'
 
-   **Example Response:**
+   **Example Response** (returned with status ``200``):
 
    .. code-block:: json
 
@@ -195,19 +298,22 @@ Create Global Tag
         "name": "MyNewGT_v1.0",
         "author": "researcher",
         "status": "unlocked",
-        "created": "2025-01-15T10:30:00.000000Z",
-        "updated": "2025-01-15T10:30:00.000000Z"
+        "created": "2026-07-23T00:00:26.714171",
+        "updated": "2026-07-23T00:00:26.714184"
       }
 
-   If the referenced status does not exist, the endpoint returns
-   ``{"detail": "GlobalTagStatus not found."}`` with status ``500``.
+   If the referenced status does not exist, the request fails with an unhandled
+   server error (``500`` with an HTML body, no JSON ``detail``). A duplicate name
+   returns ``400`` with ``{"name": ["global tag with this name already exists."]}``.
 
 Clone Global Tag
 ~~~~~~~~~~~~~~~~
 
 .. http:post:: /api/cdb_rest/global-tags/(str:source_name)/clone/(str:target_name)
 
-   Create a copy of an existing global tag with all its payload lists.
+   Create a deep copy of an existing global tag with all its payload lists and payload
+   IOVs. The clone is always created with status ``unlocked``, and the copied payload
+   lists get new auto-generated names (payload type + new sequence ID).
 
    **Alias of:** ``POST /api/cdb_rest/cloneGlobalTag/(str:source_name)/(str:target_name)`` (legacy path)
 
@@ -221,6 +327,21 @@ Clone Global Tag
    .. code-block:: bash
 
       curl -X POST http://localhost:8000/api/cdb_rest/global-tags/sPHENIX_ExampleGT_24/clone/sPHENIX_ExampleGT_25
+
+   **Example Response** (returned with status ``200``):
+
+   .. code-block:: json
+
+      {
+        "id": 2,
+        "name": "sPHENIX_ExampleGT_25",
+        "author": "admin",
+        "status": "unlocked",
+        "payload_lists_count": 1,
+        "payload_iov_count": 2,
+        "created": "2026-07-23T00:05:56.668964",
+        "updated": "2026-07-23T00:05:56.668982"
+      }
 
 Change Global Tag Status
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -241,6 +362,22 @@ Change Global Tag Status
    .. code-block:: bash
 
       curl -X PUT http://localhost:8000/api/cdb_rest/global-tags/MyNewGT_v1.0/change-status/locked
+
+   **Example Response** (note: ``status`` is the numeric status ID here):
+
+   .. code-block:: json
+
+      {
+        "id": 1,
+        "name": "MyNewGT_v1.0",
+        "author": "researcher",
+        "status": 2,
+        "created": "2026-07-23T00:00:26.714171",
+        "updated": "2026-07-23T00:05:56.720634"
+      }
+
+   If the global tag or the new status does not exist, the request fails with an
+   unhandled server error (``500`` with an HTML body).
 
    **Status semantics:**
 
@@ -266,27 +403,74 @@ Delete Global Tag
 
       curl -X DELETE http://localhost:8000/api/cdb_rest/global-tags/MyNewGT_v1.0/delete
 
+   **Example Response** (returned with status ``200``):
+
+   .. code-block:: json
+
+      {"detail": "Global tag MyNewGT_v1.0 deleted."}
+
+   A nonexistent name returns ``500`` with
+   ``{"detail": "GlobalTag MyNewGT_v1.0 doesn't exist"}``; a locked or frozen tag
+   returns ``500`` with ``{"detail": "Global Tag is locked."}``.
+
    .. warning::
       This operation is irreversible and will delete all associated payload lists!
 
    .. note::
       Global tags with status ``locked`` or ``frozen`` cannot be deleted.
 
-Global Tag Status Management
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+List Global Tag Statuses
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. http:get:: /api/cdb_rest/global-tags/statuses
-.. http:post:: /api/cdb_rest/global-tags/statuses
 
-   Manage global tag status definitions.
+   List all global tag status definitions.
 
-   **Alias of:** ``GET/POST /api/cdb_rest/gtstatus`` (legacy path)
+   **Alias of:** ``GET /api/cdb_rest/gtstatus`` (legacy path)
 
-   **Example Request (GET):**
+   **Example Request:**
 
    .. code-block:: bash
 
       curl http://localhost:8000/api/cdb_rest/global-tags/statuses
+
+   **Example Response:**
+
+   .. code-block:: json
+
+      [
+        {"id": 1, "name": "unlocked", "created": "2026-07-23T00:00:17.077708"},
+        {"id": 2, "name": "locked", "created": "2026-07-23T00:04:43.019022"},
+        {"id": 3, "name": "frozen", "created": "2026-07-23T00:04:43.062519"}
+      ]
+
+Create Global Tag Status
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. http:post:: /api/cdb_rest/global-tags/statuses
+
+   Create a new global tag status definition. Statuses must be created before any
+   global tag can reference them — a fresh database has none, so creating ``unlocked``
+   (and typically ``locked`` and ``frozen``, which carry the semantics described under
+   *Change Global Tag Status*) is the first step of any setup.
+
+   **Alias of:** ``POST /api/cdb_rest/gtstatus`` (legacy path)
+
+   :<json string name: Status name (required, unique)
+
+   **Example Request:**
+
+   .. code-block:: bash
+
+      curl -X POST http://localhost:8000/api/cdb_rest/global-tags/statuses \
+        -H "Content-Type: application/json" \
+        -d '{"name": "unlocked"}'
+
+   **Example Response** (returned with status ``200``):
+
+   .. code-block:: json
+
+      {"id": 1, "name": "unlocked", "created": "2026-07-23T00:00:17.077708"}
 
 Payload Type Endpoints
 ======================
@@ -298,7 +482,7 @@ List Payload Types
 
 .. http:get:: /api/cdb_rest/payload-types
 
-   Retrieve all payload types.
+   Retrieve all payload types. Supports :ref:`browse mode <browse-mode>` via ``?page=``.
 
    **Alias of:** ``GET /api/cdb_rest/pt`` (legacy path)
 
@@ -316,12 +500,12 @@ List Payload Types
         {
           "id": 1,
           "name": "Beam",
-          "description": "Beam parameters and conditions"
+          "created": "2026-07-23T00:04:43.190267"
         },
         {
           "id": 2,
           "name": "SiPixelQuality",
-          "description": "Silicon pixel detector quality flags"
+          "created": "2026-07-23T00:04:44.100213"
         }
       ]
 
@@ -335,7 +519,10 @@ Create Payload Type
    **Alias of:** ``POST /api/cdb_rest/pt`` (legacy path)
 
    :<json string name: Payload type name (required, unique)
-   :<json string description: Description of the payload type (optional)
+
+   .. note::
+      Although the underlying model has a ``description`` column, it is not exposed
+      through the API — a ``description`` field in the request body is silently ignored.
 
    **Example Request:**
 
@@ -343,10 +530,13 @@ Create Payload Type
 
       curl -X POST http://localhost:8000/api/cdb_rest/payload-types \
         -H "Content-Type: application/json" \
-        -d '{
-          "name": "CEMC_Calibration",
-          "description": "Electromagnetic calorimeter calibration constants"
-        }'
+        -d '{"name": "CEMC_Calibration"}'
+
+   **Example Response** (returned with status ``200``):
+
+   .. code-block:: json
+
+      {"id": 1, "name": "CEMC_Calibration", "created": "2026-07-23T00:04:43.190267"}
 
 Delete Payload Type
 ~~~~~~~~~~~~~~~~~~~
@@ -366,6 +556,15 @@ Delete Payload Type
 
       curl -X DELETE http://localhost:8000/api/cdb_rest/payload-types/CEMC_Calibration/delete
 
+   **Example Response** (returned with status ``200``):
+
+   .. code-block:: json
+
+      {"detail": "Payload Type CEMC_Calibration deleted."}
+
+   A payload type still referenced by payload lists cannot be deleted; the request
+   returns ``500`` with ``{"detail": "PayloadType is used by 1 PayloadLists"}``.
+
 Payload List Endpoints
 ======================
 
@@ -376,7 +575,10 @@ List Payload Lists
 
 .. http:get:: /api/cdb_rest/payload-lists
 
-   Retrieve all payload lists.
+   Retrieve all payload lists, each with its payload IOVs fully nested (this can be
+   large). Supports :ref:`browse mode <browse-mode>` via ``?page=``, which returns
+   flat rows with an ``iov_count`` instead of nested IOVs, filterable by
+   ``?global_tag=`` and ``?payload_type=``.
 
    **Alias of:** ``GET /api/cdb_rest/pl`` (legacy path)
 
@@ -391,7 +593,8 @@ Get Payload Lists for Global Tag
 
 .. http:get:: /api/cdb_rest/global-tags/(str:gt_name)/payload-lists
 
-   Retrieve all payload lists associated with a specific global tag.
+   Retrieve all payload lists associated with a specific global tag, as a
+   ``{payload_type: payload_list_name}`` map.
 
    **Alias of:** ``GET /api/cdb_rest/gtPayloadLists/(str:gt_name)`` (legacy path)
 
@@ -403,6 +606,12 @@ Get Payload Lists for Global Tag
    .. code-block:: bash
 
       curl http://localhost:8000/api/cdb_rest/global-tags/sPHENIX_ExampleGT_24/payload-lists
+
+   **Example Response:**
+
+   .. code-block:: json
+
+      {"Beam": "Beam_210", "CEMC_Calibration": "CEMC_Calibration_42"}
 
 Create Payload List
 ~~~~~~~~~~~~~~~~~~~
@@ -436,8 +645,11 @@ Create Payload List
         "name": "CEMC_Calibration_42",
         "global_tag": null,
         "payload_type": "CEMC_Calibration",
-        "created": "2026-01-15T10:30:00.000000Z"
+        "created": "2026-07-23T00:05:09.713172"
       }
+
+   If the referenced payload type does not exist, the request fails with an unhandled
+   server error (``500`` with an HTML body).
 
 Get Payload List by Name
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -466,8 +678,10 @@ Get Payload List by Name
         "global_tag": "sPHENIX_ExampleGT_24",
         "payload_type": "Beam",
         "iov_count": 12,
-        "created": "2022-02-21T15:10:00.000000Z"
+        "created": "2022-02-21T15:10:00.000000"
       }
+
+   Unknown names return ``404`` with ``{"detail": "Not found."}``.
 
 Attach Payload List to Global Tag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -494,12 +708,28 @@ Attach Payload List to Global Tag
           "payload_list": "CEMC_Calibration_42"
         }'
 
+   **Example Response** (returned with status ``200``):
+
+   .. code-block:: json
+
+      {
+        "id": 42,
+        "name": "CEMC_Calibration_42",
+        "global_tag": "sPHENIX_ExampleGT_24",
+        "payload_type": "CEMC_Calibration",
+        "created": "2026-07-23T00:05:09.713172"
+      }
+
+   If the global tag or payload list does not exist, the request fails with an
+   unhandled server error (``500`` with an HTML body).
+
 Delete Payload List
 ~~~~~~~~~~~~~~~~~~~
 
 .. http:delete:: /api/cdb_rest/payload-lists/(str:name)/delete
 
-   Delete a payload list and all associated payload IOVs.
+   Delete a payload list. A list that still contains payload IOVs cannot be deleted —
+   the request returns ``500`` with ``{"detail": "PayloadList contains 2 PayloadIOVs"}``.
 
    **Alias of:** ``DELETE /api/cdb_rest/deletePayloadList/(str:name)`` (legacy path)
 
@@ -510,12 +740,37 @@ Delete Payload List
 
    .. code-block:: bash
 
-      curl -X DELETE http://localhost:8000/api/cdb_rest/payload-lists/CEMC_Calibration_v1.0/delete
+      curl -X DELETE http://localhost:8000/api/cdb_rest/payload-lists/CEMC_Calibration_42/delete
+
+   **Example Response** (returned with status ``200``; the message says "Payload Type"
+   due to a quirk in the implementation, but it is the payload *list* that is deleted):
+
+   .. code-block:: json
+
+      {"detail": "Payload Type CEMC_Calibration_42 deleted."}
 
 Payload IOV Endpoints
 =====================
 
 Payload IOVs (Intervals of Validity) represent individual conditions data entries with their validity ranges.
+
+List Payload IOVs
+~~~~~~~~~~~~~~~~~
+
+.. http:get:: /api/cdb_rest/payload-iovs
+
+   Retrieve all payload IOVs in the system (this can be very large). Supports
+   :ref:`browse mode <browse-mode>` via ``?page=``, which returns flat rows including
+   the ``global_tag`` and ``payload_type`` names, filterable by ``?payload_list=``,
+   ``?global_tag=`` and ``?payload_type=``.
+
+   **Alias of:** ``GET /api/cdb_rest/piov`` (legacy path)
+
+   **Example Request:**
+
+   .. code-block:: bash
+
+      curl 'http://localhost:8000/api/cdb_rest/payload-iovs?page=1&global_tag=sPHENIX_ExampleGT_24'
 
 Main Payload Query Endpoint
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -552,7 +807,7 @@ Main Payload Query Endpoint
    .. code-block:: json
 
       [
-        ["Beam", "D0DXMagnets.dat", "e99a18c428cb38d5f260853678922e03", 1024,
+        ["Beam", "D0DXMagnets.dat", "e99a18c428cb38d5f260853678922e03", null,
          0, 999999, 9223372036854775807, 9223372036854775807, null]
       ]
 
@@ -565,7 +820,7 @@ Main Payload Query Endpoint
           "payload_type_name": "Beam",
           "payload_url": "D0DXMagnets.dat",
           "checksum": "e99a18c428cb38d5f260853678922e03",
-          "size": 1024,
+          "size": null,
           "major_iov": 0,
           "minor_iov": 999999,
           "major_iov_end": 9223372036854775807,
@@ -573,6 +828,11 @@ Main Payload Query Endpoint
           "revision": null
         }
       ]
+
+   .. note::
+      The ``size`` and ``revision`` (``extra``) columns exist in the database but
+      cannot be set through the REST API, so they are ``null`` unless populated
+      by other means.
 
    .. note::
       The underlying SQL query is selected by the ``CDB_PAYLOAD_IOVS_QUERY`` setting in
@@ -593,11 +853,14 @@ Create Payload IOV
 
    :<json string payload_url: URL/path to payload file (required)
    :<json string checksum: File checksum (required)
-   :<json int size: File size in bytes (optional)
    :<json int major_iov: Major IOV start (required)
    :<json int minor_iov: Minor IOV start (required)
    :<json int major_iov_end: Major IOV end (optional, defaults to ``sys.maxsize``)
    :<json int minor_iov_end: Minor IOV end (optional, defaults to ``sys.maxsize``)
+
+   .. note::
+      A ``size`` field in the request body is silently ignored — the serializer does
+      not expose the model's ``size`` column.
 
    **IOV range validation** depends on the ``CDB_IOV_MODE`` setting (see :ref:`iov-modes`):
 
@@ -616,14 +879,13 @@ Create Payload IOV
         -d '{
           "payload_url": "calibration_data_v1.2.root",
           "checksum": "sha256:abcd1234ef567890...",
-          "size": 2048000,
           "major_iov": 0,
           "minor_iov": 1000,
           "major_iov_end": 0,
           "minor_iov_end": 2000
         }'
 
-   **Example Response:**
+   **Example Response** (returned with status ``200``):
 
    .. code-block:: json
 
@@ -637,7 +899,7 @@ Create Payload IOV
         "major_iov_end": 0,
         "minor_iov_end": 2000,
         "payload_list": null,
-        "inserted": "2026-01-15T10:30:00.000000Z"
+        "inserted": "2026-07-23T00:05:09.831925"
       }
 
 Bulk Create Payload IOVs
@@ -675,6 +937,9 @@ Bulk Create Payload IOVs
           }
         ]'
 
+   On success the endpoint returns ``200`` with an **empty** response body. Note that
+   ``checksum`` cannot be provided through this endpoint and is left unset.
+
 Attach Payload IOV to List
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -709,12 +974,34 @@ Attach Payload IOV to List
           "piov_id": 1
         }'
 
+   **Example Response** (the updated payload IOV, returned with status ``200``):
+
+   .. code-block:: json
+
+      {
+        "id": 1,
+        "payload_url": "calibration_data_v1.2.root",
+        "checksum": "sha256:abcd1234ef567890...",
+        "major_iov": 0,
+        "minor_iov": 1000,
+        "comb_iov": "0.0000000000000001000",
+        "major_iov_end": 0,
+        "minor_iov_end": 2000,
+        "payload_list": "Beam_210",
+        "inserted": "2026-07-23T00:05:09.831925"
+      }
+
+   If the payload list or the payload IOV does not exist, the request fails with an
+   unhandled server error (``500`` with an HTML body).
+
 Delete Payload IOV
 ~~~~~~~~~~~~~~~~~~
 
 .. http:delete:: /api/cdb_rest/payload-iovs/(str:gtName)/(str:payloadType)/(int:majorIOV)/(int:minorIOV)/delete
 
-   Delete a specific payload IOV.
+   Delete a single **open-ended** payload IOV. The omitted end values default to
+   ``sys.maxsize``, so this form only matches an IOV whose ``major_iov_end`` and
+   ``minor_iov_end`` are both ``sys.maxsize``.
 
    **Alias of:** ``DELETE /api/cdb_rest/deletePayloadIOV/(str:gtName)/(str:payloadType)/(int:majorIOV)/(int:minorIOV)`` (legacy path)
 
@@ -725,7 +1012,8 @@ Delete Payload IOV
 
 .. http:delete:: /api/cdb_rest/payload-iovs/(str:gtName)/(str:payloadType)/(int:majorIOV)/(int:minorIOV)/(int:majorIOVEnd)/(int:minorIOVEnd)/delete
 
-   Delete payload IOVs in a range.
+   Delete the single payload IOV whose start **and** end values match exactly. This is
+   **not** a range delete — it never removes more than one IOV.
 
    **Alias of:** ``DELETE /api/cdb_rest/deletePayloadIOV/(str:gtName)/(str:payloadType)/(int:majorIOV)/(int:minorIOV)/(int:majorIOVEnd)/(int:minorIOVEnd)`` (legacy path)
 
@@ -733,11 +1021,21 @@ Delete Payload IOV
 
    .. code-block:: bash
 
-      # Delete specific IOV
+      # Delete an open-ended IOV (ends implicitly sys.maxsize)
       curl -X DELETE http://localhost:8000/api/cdb_rest/payload-iovs/sPHENIX_ExampleGT_24/Beam/0/1000/delete
 
-      # Delete range of IOVs
+      # Delete an IOV with explicit end values (exact match required)
       curl -X DELETE http://localhost:8000/api/cdb_rest/payload-iovs/sPHENIX_ExampleGT_24/Beam/0/1000/0/2000/delete
+
+   **Example Response** (returned with status ``200``):
+
+   .. code-block:: json
+
+      {"detail": "PayloadIOV calibration_data_v1.2.root deleted."}
+
+   If no IOV matches all parameters exactly, the request returns ``500`` with
+   ``{"detail": "PayloadIOV with given parameters doesn't exist"}``. IOVs in a
+   ``frozen`` global tag cannot be deleted; ``locked`` tags allow deletion.
 
 .. _iov-modes:
 
@@ -767,8 +1065,7 @@ Settings Endpoint
 
 .. http:get:: /api/cdb_rest/settings/(str:name)/
 
-   Read-only access to the server's ``CDB_*`` configuration values (all environment
-   variables prefixed with ``CDB_``).
+   Read-only access to the server's ``CDB_*`` configuration values.
 
    **Alias of:** ``GET /api/cdb_rest/user_settings/(str:name)/`` (legacy path)
 
@@ -787,7 +1084,31 @@ Settings Endpoint
 
       {"CDB_IOV_MODE": "continuous"}
 
-   Unknown names return ``404`` with ``{"detail": "Setting 'NAME' not found."}``.
+   .. warning::
+      Only ``CDB_``-prefixed variables that are actually **set in the server's
+      environment** are exposed. Settings that merely fall back to an in-code default
+      (e.g. ``CDB_IOV_MODE`` when the environment variable is unset, as in the default
+      Docker setup) return ``404`` like unknown names:
+      ``{"detail": "Setting 'CDB_IOV_MODE' not found."}``.
+
+Lookup by ID
+============
+
+In addition to the name-based endpoints above, each resource can be retrieved by its
+numeric primary key. Unknown IDs return ``404`` with ``{"detail": "Not found."}``.
+
+.. http:get:: /api/cdb_rest/gt/(int:id)
+
+   Retrieve a global tag by ID (full nested representation, no alias path).
+
+.. http:get:: /api/cdb_rest/payload-lists/(int:id)
+
+   Retrieve a payload list by ID. **Alias of:** ``GET /api/cdb_rest/pl/(int:id)``.
+   Note: ``global_tag`` and ``payload_type`` are returned as numeric IDs here.
+
+.. http:get:: /api/cdb_rest/payload-iovs/(int:id)
+
+   Retrieve a payload IOV by ID. **Alias of:** ``GET /api/cdb_rest/piov/(int:id)``.
 
 Utility Endpoints
 =================
@@ -844,25 +1165,19 @@ Common HTTP Status Codes
      - Description
    * - 200
      - OK
-     - Successful GET request
-   * - 201
-     - Created
-     - Resource created successfully  
-   * - 204
-     - No Content
-     - Successful DELETE request
+     - Successful request — including creates (POST), updates (PUT) and deletes (DELETE)
    * - 400
      - Bad Request
-     - Invalid request data or missing required fields
+     - Invalid request data, missing required fields, or duplicate names (serializer validation)
+   * - 403
+     - Forbidden
+     - Rejected by the configured permission plugin
    * - 404
      - Not Found
-     - Resource not found (global tag, payload type, etc.)
-   * - 409
-     - Conflict
-     - Resource already exists (duplicate names)
+     - Detail lookup by ID/name failed, or unknown setting name
    * - 500
      - Internal Server Error
-     - Server error (check logs)
+     - Business-logic errors (missing referenced resources, locked/frozen global tags, IOV conflicts) and unhandled server errors
 
 Error Response Format
 ~~~~~~~~~~~~~~~~~~~~~
@@ -877,7 +1192,11 @@ Error responses use a single ``detail`` field:
 
 .. note::
    Most business-logic errors (missing resources, immutable global tags, IOV conflicts) are
-   currently returned with status ``500`` rather than ``404``/``409``.
+   currently returned with status ``500``. In addition, some
+   "referenced resource not found" cases (e.g. creating a global tag with a nonexistent
+   status, attaching to a nonexistent payload list, cloning a nonexistent global tag) are
+   unhandled in the code and return a generic ``500`` with an **HTML** error page instead
+   of a JSON body.
 
 Validation Errors
 ~~~~~~~~~~~~~~~~~
@@ -897,13 +1216,6 @@ Performance Tips
 Query Optimization
 ~~~~~~~~~~~~~~~~~~
 
-1. **Batch Operations**: Use bulk endpoints for multiple operations
+1. **Batch Operations**: Use bulk endpoint for multiple operations
 2. **Appropriate IOV Ranges**: Use precise IOV ranges to limit result sets
 3. **Caching**: Cache frequently accessed data on the client side
-
-Database Considerations
-~~~~~~~~~~~~~~~~~~~~~~~
-
-- The main ``/payload-iovs/query/`` endpoint is optimized for complex queries
-- Bulk operations are significantly faster than individual requests
-- Consider using read replicas for high-load query scenarios

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -13,9 +13,6 @@ Nopayloaddb provides a RESTful API for managing global tags, payload types, payl
 Quick Start
 ===========
 
-.. note::
-   **Try it now**: If you have Nopayloaddb running locally, you can test these examples immediately!
-
 **Base URL**
 
 All API endpoints are prefixed with ``/api/cdb_rest/``. For example:
@@ -41,7 +38,7 @@ Verify your installation with this simple command:
 
 .. code-block:: bash
 
-   curl http://localhost:8000/api/cdb_rest/gt
+   curl http://localhost:8000/api/cdb_rest/global-tags
 
 **Response Formats**
 
@@ -98,15 +95,17 @@ Global Tags represent named collections of payload versions for consistent condi
 List All Global Tags
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. http:get:: /api/cdb_rest/globalTags
+.. http:get:: /api/cdb_rest/global-tags
 
    Retrieve a list of all global tags in the system.
+
+   **Alias of:** ``GET /api/cdb_rest/globalTags`` (legacy path)
 
    **Example Request:**
 
    .. code-block:: bash
 
-      curl http://localhost:8000/api/cdb_rest/globalTags
+      curl http://localhost:8000/api/cdb_rest/global-tags
 
    **Example Response:**
 
@@ -126,9 +125,11 @@ List All Global Tags
 Get Global Tag by Name
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. http:get:: /api/cdb_rest/globalTag/(str:name)
+.. http:get:: /api/cdb_rest/global-tags/(str:name)
 
    Retrieve detailed information about a specific global tag.
+
+   **Alias of:** ``GET /api/cdb_rest/globalTag/(str:name)`` (legacy path)
 
    :param name: Global tag name
    :type name: string
@@ -137,7 +138,7 @@ Get Global Tag by Name
 
    .. code-block:: bash
 
-      curl http://localhost:8000/api/cdb_rest/globalTag/sPHENIX_ExampleGT_24
+      curl http://localhost:8000/api/cdb_rest/global-tags/sPHENIX_ExampleGT_24
 
    **Example Response:**
 
@@ -204,9 +205,11 @@ Create Global Tag
 Clone Global Tag
 ~~~~~~~~~~~~~~~~
 
-.. http:post:: /api/cdb_rest/cloneGlobalTag/(str:source_name)/(str:target_name)
+.. http:post:: /api/cdb_rest/global-tags/(str:source_name)/clone/(str:target_name)
 
    Create a copy of an existing global tag with all its payload lists.
+
+   **Alias of:** ``POST /api/cdb_rest/cloneGlobalTag/(str:source_name)/(str:target_name)`` (legacy path)
 
    :param source_name: Name of the global tag to clone
    :param target_name: Name for the new global tag
@@ -217,14 +220,16 @@ Clone Global Tag
 
    .. code-block:: bash
 
-      curl -X POST http://localhost:8000/api/cdb_rest/cloneGlobalTag/sPHENIX_ExampleGT_24/sPHENIX_ExampleGT_25
+      curl -X POST http://localhost:8000/api/cdb_rest/global-tags/sPHENIX_ExampleGT_24/clone/sPHENIX_ExampleGT_25
 
 Change Global Tag Status
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. http:put:: /api/cdb_rest/gt_change_status/(str:name)/(str:newStatus)
+.. http:put:: /api/cdb_rest/global-tags/(str:name)/change-status/(str:newStatus)
 
    Update the status of a global tag
+
+   **Alias of:** ``PUT /api/cdb_rest/gt_change_status/(str:name)/(str:newStatus)`` (legacy path)
 
    :param name: Global tag name
    :param newStatus: New status **name** — must be an existing GlobalTagStatus
@@ -235,7 +240,7 @@ Change Global Tag Status
 
    .. code-block:: bash
 
-      curl -X PUT http://localhost:8000/api/cdb_rest/gt_change_status/MyNewGT_v1.0/locked
+      curl -X PUT http://localhost:8000/api/cdb_rest/global-tags/MyNewGT_v1.0/change-status/locked
 
    **Status semantics:**
 
@@ -246,9 +251,11 @@ Change Global Tag Status
 Delete Global Tag
 ~~~~~~~~~~~~~~~~~
 
-.. http:delete:: /api/cdb_rest/deleteGlobalTag/(str:name)
+.. http:delete:: /api/cdb_rest/global-tags/(str:name)/delete
 
    Delete a global tag and all associated payload lists.
+
+   **Alias of:** ``DELETE /api/cdb_rest/deleteGlobalTag/(str:name)`` (legacy path)
 
    :param name: Global tag name
    :type name: string
@@ -257,7 +264,7 @@ Delete Global Tag
 
    .. code-block:: bash
 
-      curl -X DELETE http://localhost:8000/api/cdb_rest/deleteGlobalTag/MyNewGT_v1.0
+      curl -X DELETE http://localhost:8000/api/cdb_rest/global-tags/MyNewGT_v1.0/delete
 
    .. warning::
       This operation is irreversible and will delete all associated payload lists!
@@ -268,16 +275,18 @@ Delete Global Tag
 Global Tag Status Management
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. http:get:: /api/cdb_rest/gtstatus
-.. http:post:: /api/cdb_rest/gtstatus
+.. http:get:: /api/cdb_rest/global-tags/statuses
+.. http:post:: /api/cdb_rest/global-tags/statuses
 
    Manage global tag status definitions.
+
+   **Alias of:** ``GET/POST /api/cdb_rest/gtstatus`` (legacy path)
 
    **Example Request (GET):**
 
    .. code-block:: bash
 
-      curl http://localhost:8000/api/cdb_rest/gtstatus
+      curl http://localhost:8000/api/cdb_rest/global-tags/statuses
 
 Payload Type Endpoints
 ======================
@@ -287,15 +296,17 @@ Payload Types define categories and structures for different kinds of conditions
 List Payload Types
 ~~~~~~~~~~~~~~~~~~
 
-.. http:get:: /api/cdb_rest/pt
+.. http:get:: /api/cdb_rest/payload-types
 
    Retrieve all payload types.
+
+   **Alias of:** ``GET /api/cdb_rest/pt`` (legacy path)
 
    **Example Request:**
 
    .. code-block:: bash
 
-      curl http://localhost:8000/api/cdb_rest/pt
+      curl http://localhost:8000/api/cdb_rest/payload-types
 
    **Example Response:**
 
@@ -317,9 +328,11 @@ List Payload Types
 Create Payload Type
 ~~~~~~~~~~~~~~~~~~~
 
-.. http:post:: /api/cdb_rest/pt
+.. http:post:: /api/cdb_rest/payload-types
 
    Create a new payload type.
+
+   **Alias of:** ``POST /api/cdb_rest/pt`` (legacy path)
 
    :<json string name: Payload type name (required, unique)
    :<json string description: Description of the payload type (optional)
@@ -328,7 +341,7 @@ Create Payload Type
 
    .. code-block:: bash
 
-      curl -X POST http://localhost:8000/api/cdb_rest/pt \
+      curl -X POST http://localhost:8000/api/cdb_rest/payload-types \
         -H "Content-Type: application/json" \
         -d '{
           "name": "CEMC_Calibration",
@@ -338,9 +351,11 @@ Create Payload Type
 Delete Payload Type
 ~~~~~~~~~~~~~~~~~~~
 
-.. http:delete:: /api/cdb_rest/deletePayloadType/(str:name)
+.. http:delete:: /api/cdb_rest/payload-types/(str:name)/delete
 
    Delete a payload type.
+
+   **Alias of:** ``DELETE /api/cdb_rest/deletePayloadType/(str:name)`` (legacy path)
 
    :param name: Payload type name
    :type name: string
@@ -349,7 +364,7 @@ Delete Payload Type
 
    .. code-block:: bash
 
-      curl -X DELETE http://localhost:8000/api/cdb_rest/deletePayloadType/CEMC_Calibration
+      curl -X DELETE http://localhost:8000/api/cdb_rest/payload-types/CEMC_Calibration/delete
 
 Payload List Endpoints
 ======================
@@ -359,22 +374,26 @@ Payload Lists link Global Tags to Payload Types and serve as containers for payl
 List Payload Lists
 ~~~~~~~~~~~~~~~~~~
 
-.. http:get:: /api/cdb_rest/pl
+.. http:get:: /api/cdb_rest/payload-lists
 
    Retrieve all payload lists.
+
+   **Alias of:** ``GET /api/cdb_rest/pl`` (legacy path)
 
    **Example Request:**
 
    .. code-block:: bash
 
-      curl http://localhost:8000/api/cdb_rest/pl
+      curl http://localhost:8000/api/cdb_rest/payload-lists
 
 Get Payload Lists for Global Tag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. http:get:: /api/cdb_rest/gtPayloadLists/(str:gt_name)
+.. http:get:: /api/cdb_rest/global-tags/(str:gt_name)/payload-lists
 
    Retrieve all payload lists associated with a specific global tag.
+
+   **Alias of:** ``GET /api/cdb_rest/gtPayloadLists/(str:gt_name)`` (legacy path)
 
    :param gt_name: Global tag name
    :type gt_name: string
@@ -383,16 +402,18 @@ Get Payload Lists for Global Tag
 
    .. code-block:: bash
 
-      curl http://localhost:8000/api/cdb_rest/gtPayloadLists/sPHENIX_ExampleGT_24
+      curl http://localhost:8000/api/cdb_rest/global-tags/sPHENIX_ExampleGT_24/payload-lists
 
 Create Payload List
 ~~~~~~~~~~~~~~~~~~~
 
-.. http:post:: /api/cdb_rest/pl
+.. http:post:: /api/cdb_rest/payload-lists
 
    Create a new payload list. The name is **auto-generated** from the payload type name and
    an internal sequence ID (e.g. ``CEMC_Calibration_42``); the list is created detached
-   (``global_tag: null``) and must be attached with ``pl_attach``.
+   (``global_tag: null``) and must be attached with ``payload-lists/attach``.
+
+   **Alias of:** ``POST /api/cdb_rest/pl`` (legacy path)
 
    :<json string payload_type: Payload type **name** (required) — must be an existing PayloadType
 
@@ -400,7 +421,7 @@ Create Payload List
 
    .. code-block:: bash
 
-      curl -X POST http://localhost:8000/api/cdb_rest/pl \
+      curl -X POST http://localhost:8000/api/cdb_rest/payload-lists \
         -H "Content-Type: application/json" \
         -d '{
           "payload_type": "CEMC_Calibration"
@@ -418,14 +439,46 @@ Create Payload List
         "created": "2026-01-15T10:30:00.000000Z"
       }
 
+Get Payload List by Name
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. http:get:: /api/cdb_rest/payload-lists/by-name/(str:name)
+
+   Retrieve a payload list's metadata by name, including the number of attached payload
+   IOVs (``iov_count``). Nested IOVs are not included. This endpoint has no legacy path.
+
+   :param name: Payload list name
+   :type name: string
+
+   **Example Request:**
+
+   .. code-block:: bash
+
+      curl http://localhost:8000/api/cdb_rest/payload-lists/by-name/Beam_210
+
+   **Example Response:**
+
+   .. code-block:: json
+
+      {
+        "id": 210,
+        "name": "Beam_210",
+        "global_tag": "sPHENIX_ExampleGT_24",
+        "payload_type": "Beam",
+        "iov_count": 12,
+        "created": "2022-02-21T15:10:00.000000Z"
+      }
+
 Attach Payload List to Global Tag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. http:put:: /api/cdb_rest/pl_attach
+.. http:put:: /api/cdb_rest/payload-lists/attach
 
    Attach an existing payload list to a global tag. If the global tag already has a payload
    list of the same payload type, that list is detached first. Rejected if the global tag is
    ``frozen``, or if it is ``locked`` and a list of the same type is already attached.
+
+   **Alias of:** ``PUT /api/cdb_rest/pl_attach`` (legacy path)
 
    :<json string global_tag: Global tag name (required)
    :<json string payload_list: Payload list name (required)
@@ -434,7 +487,7 @@ Attach Payload List to Global Tag
 
    .. code-block:: bash
 
-      curl -X PUT http://localhost:8000/api/cdb_rest/pl_attach \
+      curl -X PUT http://localhost:8000/api/cdb_rest/payload-lists/attach \
         -H "Content-Type: application/json" \
         -d '{
           "global_tag": "sPHENIX_ExampleGT_24",
@@ -444,9 +497,11 @@ Attach Payload List to Global Tag
 Delete Payload List
 ~~~~~~~~~~~~~~~~~~~
 
-.. http:delete:: /api/cdb_rest/deletePayloadList/(str:name)
+.. http:delete:: /api/cdb_rest/payload-lists/(str:name)/delete
 
    Delete a payload list and all associated payload IOVs.
+
+   **Alias of:** ``DELETE /api/cdb_rest/deletePayloadList/(str:name)`` (legacy path)
 
    :param name: Payload list name
    :type name: string
@@ -455,7 +510,7 @@ Delete Payload List
 
    .. code-block:: bash
 
-      curl -X DELETE http://localhost:8000/api/cdb_rest/deletePayloadList/CEMC_Calibration_v1.0
+      curl -X DELETE http://localhost:8000/api/cdb_rest/payload-lists/CEMC_Calibration_v1.0/delete
 
 Payload IOV Endpoints
 =====================
@@ -465,12 +520,14 @@ Payload IOVs (Intervals of Validity) represent individual conditions data entrie
 Main Payload Query Endpoint
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. http:get:: /api/cdb_rest/payloadiovs/
+.. http:get:: /api/cdb_rest/payload-iovs/query/
 
    **Primary endpoint** for querying payload IOVs. For each payload list attached to the
    global tag, it returns the latest payload IOV whose start is at or before the requested
    IOV point. The query runs as raw SQL for performance and is distributed randomly across
    the configured read replica databases.
+
+   **Alias of:** ``GET /api/cdb_rest/payloadiovs/`` (legacy path)
 
    :query gtName: Global tag name (required)
    :query majorIOV: Major IOV value (required)
@@ -482,10 +539,10 @@ Main Payload Query Endpoint
    .. code-block:: bash
 
       # Default (positional rows)
-      curl 'http://localhost:8000/api/cdb_rest/payloadiovs/?gtName=sPHENIX_ExampleGT_24&majorIOV=0&minorIOV=999999'
+      curl 'http://localhost:8000/api/cdb_rest/payload-iovs/query/?gtName=sPHENIX_ExampleGT_24&majorIOV=0&minorIOV=999999'
 
       # Dictionary-shaped response
-      curl 'http://localhost:8000/api/cdb_rest/payloadiovs/?gtName=sPHENIX_ExampleGT_24&majorIOV=0&minorIOV=999999&shape=dict'
+      curl 'http://localhost:8000/api/cdb_rest/payload-iovs/query/?gtName=sPHENIX_ExampleGT_24&majorIOV=0&minorIOV=999999&shape=dict'
 
    **Example Response (default):**
 
@@ -525,12 +582,14 @@ Main Payload Query Endpoint
 Create Payload IOV
 ~~~~~~~~~~~~~~~~~~
 
-.. http:post:: /api/cdb_rest/piov
+.. http:post:: /api/cdb_rest/payload-iovs
 
    Create a single payload IOV. The IOV is created **detached** — associate it with a
-   payload list afterwards using ``piov_attach``. If the end values are omitted they default
-   to ``sys.maxsize`` (open-ended IOV). A combined IOV
+   payload list afterwards using ``payload-iovs/attach``. If the end values are omitted they
+   default to ``sys.maxsize`` (open-ended IOV). A combined IOV
    (``comb_iov = major_iov + minor_iov / 10^19``) is computed automatically.
+
+   **Alias of:** ``POST /api/cdb_rest/piov`` (legacy path)
 
    :<json string payload_url: URL/path to payload file (required)
    :<json string checksum: File checksum (required)
@@ -552,7 +611,7 @@ Create Payload IOV
 
    .. code-block:: bash
 
-      curl -X POST http://localhost:8000/api/cdb_rest/piov \
+      curl -X POST http://localhost:8000/api/cdb_rest/payload-iovs \
         -H "Content-Type: application/json" \
         -d '{
           "payload_url": "calibration_data_v1.2.root",
@@ -584,20 +643,22 @@ Create Payload IOV
 Bulk Create Payload IOVs
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. http:post:: /api/cdb_rest/bulk_piov
+.. http:post:: /api/cdb_rest/payload-iovs/bulk
 
    Create multiple payload IOVs in a single operation for improved performance. Unlike
-   ``piov``, each entry is attached directly to a payload list (by name), end IOVs are always
-   set to ``sys.maxsize`` (open-ended), and individual range validation is skipped.
+   ``payload-iovs``, each entry is attached directly to a payload list (by name), end IOVs
+   are always set to ``sys.maxsize`` (open-ended), and individual range validation is skipped.
 
    Each array element requires ``payload_url``, ``major_iov``, ``minor_iov`` and
    ``payload_list`` (payload list **name**).
+
+   **Alias of:** ``POST /api/cdb_rest/bulk_piov`` (legacy path)
 
    **Example Request:**
 
    .. code-block:: bash
 
-      curl -X POST http://localhost:8000/api/cdb_rest/bulk_piov \
+      curl -X POST http://localhost:8000/api/cdb_rest/payload-iovs/bulk \
         -H "Content-Type: application/json" \
         -d '[
           {
@@ -617,7 +678,7 @@ Bulk Create Payload IOVs
 Attach Payload IOV to List
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. http:put:: /api/cdb_rest/piov_attach
+.. http:put:: /api/cdb_rest/payload-iovs/attach
 
    Attach an existing payload IOV to a payload list, resolving overlaps with the IOVs
    already in the list:
@@ -632,6 +693,8 @@ Attach Payload IOV to List
 
    Overlap comparisons honor the configured ``CDB_IOV_MODE`` (see :ref:`iov-modes`).
 
+   **Alias of:** ``PUT /api/cdb_rest/piov_attach`` (legacy path)
+
    :<json string payload_list: Payload list name (required)
    :<json int piov_id: Payload IOV ID (required)
 
@@ -639,7 +702,7 @@ Attach Payload IOV to List
 
    .. code-block:: bash
 
-      curl -X PUT http://localhost:8000/api/cdb_rest/piov_attach \
+      curl -X PUT http://localhost:8000/api/cdb_rest/payload-iovs/attach \
         -H "Content-Type: application/json" \
         -d '{
           "payload_list": "Beam_210",
@@ -649,28 +712,32 @@ Attach Payload IOV to List
 Delete Payload IOV
 ~~~~~~~~~~~~~~~~~~
 
-.. http:delete:: /api/cdb_rest/deletePayloadIOV/(str:gtName)/(str:payloadType)/(int:majorIOV)/(int:minorIOV)
+.. http:delete:: /api/cdb_rest/payload-iovs/(str:gtName)/(str:payloadType)/(int:majorIOV)/(int:minorIOV)/delete
 
    Delete a specific payload IOV.
+
+   **Alias of:** ``DELETE /api/cdb_rest/deletePayloadIOV/(str:gtName)/(str:payloadType)/(int:majorIOV)/(int:minorIOV)`` (legacy path)
 
    :param gtName: Global tag name
    :param payloadType: Payload type name
    :param majorIOV: Major IOV value
    :param minorIOV: Minor IOV value
 
-.. http:delete:: /api/cdb_rest/deletePayloadIOV/(str:gtName)/(str:payloadType)/(int:majorIOV)/(int:minorIOV)/(int:majorIOVEnd)/(int:minorIOVEnd)
+.. http:delete:: /api/cdb_rest/payload-iovs/(str:gtName)/(str:payloadType)/(int:majorIOV)/(int:minorIOV)/(int:majorIOVEnd)/(int:minorIOVEnd)/delete
 
    Delete payload IOVs in a range.
+
+   **Alias of:** ``DELETE /api/cdb_rest/deletePayloadIOV/(str:gtName)/(str:payloadType)/(int:majorIOV)/(int:minorIOV)/(int:majorIOVEnd)/(int:minorIOVEnd)`` (legacy path)
 
    **Example Request:**
 
    .. code-block:: bash
 
       # Delete specific IOV
-      curl -X DELETE http://localhost:8000/api/cdb_rest/deletePayloadIOV/sPHENIX_ExampleGT_24/Beam/0/1000
+      curl -X DELETE http://localhost:8000/api/cdb_rest/payload-iovs/sPHENIX_ExampleGT_24/Beam/0/1000/delete
 
       # Delete range of IOVs
-      curl -X DELETE http://localhost:8000/api/cdb_rest/deletePayloadIOV/sPHENIX_ExampleGT_24/Beam/0/1000/0/2000
+      curl -X DELETE http://localhost:8000/api/cdb_rest/payload-iovs/sPHENIX_ExampleGT_24/Beam/0/1000/0/2000/delete
 
 .. _iov-modes:
 
@@ -686,8 +753,8 @@ startup.
    :header-rows: 1
 
    * - Mode
-     - Range validation (``piov``)
-     - Overlap handling (``piov_attach``)
+     - Range validation (``payload-iovs``)
+     - Overlap handling (``payload-iovs/attach``)
    * - ``continuous`` (default)
      - End IOV must be strictly greater than start IOV
      - Trimmed IOVs end exactly at the new IOV's start
@@ -698,10 +765,12 @@ startup.
 Settings Endpoint
 =================
 
-.. http:get:: /api/cdb_rest/user_settings/(str:name)/
+.. http:get:: /api/cdb_rest/settings/(str:name)/
 
    Read-only access to the server's ``CDB_*`` configuration values (all environment
    variables prefixed with ``CDB_``).
+
+   **Alias of:** ``GET /api/cdb_rest/user_settings/(str:name)/`` (legacy path)
 
    :param name: Setting name, e.g. ``CDB_IOV_MODE``
    :type name: string
@@ -710,7 +779,7 @@ Settings Endpoint
 
    .. code-block:: bash
 
-      curl http://localhost:8000/api/cdb_rest/user_settings/CDB_IOV_MODE/
+      curl http://localhost:8000/api/cdb_rest/settings/CDB_IOV_MODE/
 
    **Example Response:**
 
@@ -748,7 +817,7 @@ Get All Conditions for a Run
 .. code-block:: bash
 
    # Get all conditions for run 12345
-   curl 'http://localhost:8000/api/cdb_rest/payloadiovs/?gtName=Production_GT_v2.1&majorIOV=0&minorIOV=12345'
+   curl 'http://localhost:8000/api/cdb_rest/payload-iovs/query/?gtName=Production_GT_v2.1&majorIOV=0&minorIOV=12345'
 
 List All Available Global Tags
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -756,7 +825,7 @@ List All Available Global Tags
 .. code-block:: bash
 
    # See what global tags are available
-   curl http://localhost:8000/api/cdb_rest/globalTags | jq '.[].name'
+   curl http://localhost:8000/api/cdb_rest/global-tags | jq '.[].name'
 
 Error Handling
 ==============
@@ -835,22 +904,6 @@ Query Optimization
 Database Considerations
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-- The main ``/payloadiovs/`` endpoint is optimized for complex queries
+- The main ``/payload-iovs/query/`` endpoint is optimized for complex queries
 - Bulk operations are significantly faster than individual requests
 - Consider using read replicas for high-load query scenarios
-
-Integration Examples
-====================
-
-Python and shell client examples live in the :doc:`usage` guide.
-
-Next Steps
-==========
-
-- **Usage Examples**: See :doc:`usage` for practical workflow examples
-- **Development**: Check :doc:`development` for API development guidelines
-- **Architecture**: Learn about the system design in :doc:`architecture`
-- **Deployment**: Production API setup in :doc:`deployment`
-
-.. tip::
-   **Interactive API Exploration**: Once you have Nopayloaddb running, you can explore the API interactively by visiting http://localhost:8000/api/cdb_rest/ in your browser (if DRF browsable API is enabled).


### PR DESCRIPTION
* Aliases are listed first as the preferred entry points, with the original name shown below ("alias of:")

* Verified every endpoint in docs/source/api.rst against both the code and a local running Docker instance, and corrected the API documentation  <-- Assisted with Claude Fable